### PR TITLE
fix diffPathToRelative

### DIFF
--- a/packages/workshop-app/app/utils/diff.server.ts
+++ b/packages/workshop-app/app/utils/diff.server.ts
@@ -14,7 +14,10 @@ const kcdshopTempDir = path.join(os.tmpdir(), 'kcdshop')
 const diffTmpDir = path.join(kcdshopTempDir, 'diff')
 
 function diffPathToRelative(filePath: string) {
-	filePath = filePath.replace(/\\\\/g, path.sep).replace(/\\|\//g, path.sep)
+	filePath = filePath
+		.replace(/\\\\/g, path.sep)
+		.replace(/\\|\//g, path.sep)
+		.replace(/^("|')|("|')$/g, '')
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [workshopRootDirname, appId, ...relativePath] = filePath
@@ -24,7 +27,6 @@ function diffPathToRelative(filePath: string) {
 				: `${diffTmpDir.slice(1)}${path.sep}`,
 			'',
 		)
-		.replace(/'|"/g, '')
 		.split(path.sep)
 
 	return relativePath.join(path.sep)

--- a/packages/workshop-app/app/utils/diff.server.ts
+++ b/packages/workshop-app/app/utils/diff.server.ts
@@ -14,10 +14,19 @@ const kcdshopTempDir = path.join(os.tmpdir(), 'kcdshop')
 const diffTmpDir = path.join(kcdshopTempDir, 'diff')
 
 function diffPathToRelative(filePath: string) {
+	filePath = filePath.replace(/\\\\/g, path.sep).replace(/\\|\//g, path.sep)
+
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [workshopRootDirname, appId, ...relativePath] = filePath
-		.replace(`${diffTmpDir.slice(1)}${path.sep}`, '')
+		.replace(
+			process.platform === 'win32'
+				? `${diffTmpDir}${path.sep}`
+				: `${diffTmpDir.slice(1)}${path.sep}`,
+			'',
+		)
+		.replace(/'|"/g, '')
 		.split(path.sep)
+
 	return relativePath.join(path.sep)
 }
 


### PR DESCRIPTION
The problem caused by `parseGitDiff`

it return mixed separators from `const parsed = parseGitDiff(diffOutput)`

`Users\\____\\AppData\\Local\\Temp\\kcdshop\\diff\\advanced-react-patterns\\exercises.01.latest-ref.01.solution-1/index.tsx"`

it also start/end with `'` or `"`

The proposed patch fix the problem by updating the function `diffPathToRelative`

i've tested it only on windows 11, and the diff work ok