### PR TITLE
fix: failed to load .env

### DIFF
--- a/packages/workshop-app/start.js
+++ b/packages/workshop-app/start.js
@@ -1,6 +1,9 @@
 const dotenv = require('dotenv')
+const path = require('path')
 
-dotenv.config({ path: process.env.KCDSHOP_CONTEXT_CWD ?? process.cwd() })
+dotenv.config({
+	path: path.join(process.env.KCDSHOP_CONTEXT_CWD ?? process.cwd(), '.env'),
+})
 
 if (process.env.NODE_ENV === 'production') {
 	require('./build/server')


### PR DESCRIPTION
Last week when we discussed `process.env.KCDSHOP_EDITOR` I did not created a `.env` file, instead I've just add it as a `windows environment variable`.

Today I've noticed that the app not loading the `.env` file at all.

On kcdshop development
```
 [dotenv@16.0.3][DEBUG] Failed to load C:\projects\kcd-apps\kcdshop\packages\example EISDIR: illegal operation on a directory, read
```

On web-app-fundamentals
```
 [dotenv@16.0.3][DEBUG] Failed to load C:\projects\kcd-apps\web-app-fundamentals EISDIR: illegal operation on a directory, read
```

Simple fix….
