### PR TITLE
chore: update to meta v2

### DIFF
--- a/packages/example/exercises/01.nested-routing/01-02.problem/app/root.tsx
+++ b/packages/example/exercises/01.nested-routing/01-02.problem/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from '@remix-run/node'
+import type { LinksFunction, V2_MetaFunction } from '@remix-run/node'
 import {
 	Links,
 	LiveReload,
@@ -14,16 +14,16 @@ export const links: LinksFunction = () => {
 	return [{ rel: 'stylesheet', href: tailwindStylesheetUrl }]
 }
 
-export const meta: MetaFunction = () => ({
-	charset: 'utf-8',
-	title: 'Remix Notes',
-	viewport: 'width=device-width,initial-scale=1',
-})
+export const meta: V2_MetaFunction = () => {
+	return [{ title: 'Remix Notes' }]
+}
 
 export default function App() {
 	return (
 		<html lang="en" className="h-full">
 			<head>
+				<meta charSet="utf-8" />
+				<meta name="viewport" content="width=device-width,initial-scale=1" />
 				<Meta />
 				<Links />
 			</head>

--- a/packages/example/exercises/01.nested-routing/01-02.problem/remix.config.js
+++ b/packages/example/exercises/01.nested-routing/01-02.problem/remix.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	cacheDirectory: './node_modules/.cache/remix',
 	ignoredRouteFiles: ['**/.*', '**/*.css', '**/*.test.{js,jsx,ts,tsx}'],
 	future: {
+		v2_meta: true,
 		unstable_postcss: true,
 	},
 }

--- a/packages/example/exercises/01.nested-routing/01.solution.outlet/app/root.tsx
+++ b/packages/example/exercises/01.nested-routing/01.solution.outlet/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from '@remix-run/node'
+import type { LinksFunction, V2_MetaFunction } from '@remix-run/node'
 import {
 	Links,
 	LiveReload,
@@ -15,16 +15,16 @@ export const links: LinksFunction = () => {
 	return [{ rel: 'stylesheet', href: tailwindStylesheetUrl }]
 }
 
-export const meta: MetaFunction = () => ({
-	charset: 'utf-8',
-	title: 'Remix Notes',
-	viewport: 'width=device-width,initial-scale=1',
-})
+export const meta: V2_MetaFunction = () => {
+	return [{ title: 'Remix Notes' }]
+}
 
 export default function App() {
 	return (
 		<html lang="en" className="h-full">
 			<head>
+				<meta charSet="utf-8" />
+				<meta name="viewport" content="width=device-width,initial-scale=1" />
 				<Meta />
 				<Links />
 			</head>

--- a/packages/example/exercises/01.nested-routing/01.solution.outlet/remix.config.js
+++ b/packages/example/exercises/01.nested-routing/01.solution.outlet/remix.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	cacheDirectory: './node_modules/.cache/remix',
 	ignoredRouteFiles: ['**/.*', '**/*.css', '**/*.test.{js,jsx,ts,tsx}'],
 	future: {
+		v2_meta: true,
 		unstable_postcss: true,
 	},
 }

--- a/packages/example/exercises/01.nested-routing/02.solution.outlet-context/app/root.tsx
+++ b/packages/example/exercises/01.nested-routing/02.solution.outlet-context/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from '@remix-run/node'
+import type { LinksFunction, V2_MetaFunction } from '@remix-run/node'
 import {
 	Links,
 	LiveReload,
@@ -15,16 +15,16 @@ export const links: LinksFunction = () => {
 	return [{ rel: 'stylesheet', href: tailwindStylesheetUrl }]
 }
 
-export const meta: MetaFunction = () => ({
-	charset: 'utf-8',
-	title: 'Remix Notes',
-	viewport: 'width=device-width,initial-scale=1',
-})
+export const meta: V2_MetaFunction = () => {
+	return [{ title: 'Remix Notes' }]
+}
 
 export default function App() {
 	return (
 		<html lang="en" className="h-full">
 			<head>
+				<meta charSet="utf-8" />
+				<meta name="viewport" content="width=device-width,initial-scale=1" />
 				<Meta />
 				<Links />
 			</head>

--- a/packages/example/exercises/01.nested-routing/02.solution.outlet-context/remix.config.js
+++ b/packages/example/exercises/01.nested-routing/02.solution.outlet-context/remix.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	cacheDirectory: './node_modules/.cache/remix',
 	ignoredRouteFiles: ['**/.*', '**/*.css', '**/*.test.{js,jsx,ts,tsx}'],
 	future: {
+		v2_meta: true,
 		unstable_postcss: true,
 	},
 }

--- a/packages/example/exercises/02.styling/01-02.problem/app/root.tsx
+++ b/packages/example/exercises/02.styling/01-02.problem/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from '@remix-run/node'
+import type { LinksFunction, V2_MetaFunction } from '@remix-run/node'
 import {
 	Links,
 	LiveReload,
@@ -15,16 +15,16 @@ export const links: LinksFunction = () => {
 	return [{ rel: 'stylesheet', href: tailwindStylesheetUrl }]
 }
 
-export const meta: MetaFunction = () => ({
-	charset: 'utf-8',
-	title: 'Remix Notes',
-	viewport: 'width=device-width,initial-scale=1',
-})
+export const meta: V2_MetaFunction = () => {
+	return [{ title: 'Remix Notes' }]
+}
 
 export default function App() {
 	return (
 		<html lang="en" className="h-full">
 			<head>
+				<meta charSet="utf-8" />
+				<meta name="viewport" content="width=device-width,initial-scale=1" />
 				<Meta />
 				<Links />
 			</head>

--- a/packages/example/exercises/02.styling/01-02.problem/remix.config.js
+++ b/packages/example/exercises/02.styling/01-02.problem/remix.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	cacheDirectory: './node_modules/.cache/remix',
 	ignoredRouteFiles: ['**/.*', '**/*.css', '**/*.test.{js,jsx,ts,tsx}'],
 	future: {
+		v2_meta: true,
 		unstable_postcss: true,
 	},
 }

--- a/packages/example/exercises/02.styling/01.solution.links/app/root.tsx
+++ b/packages/example/exercises/02.styling/01.solution.links/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from '@remix-run/node'
+import type { LinksFunction, V2_MetaFunction } from '@remix-run/node'
 import {
 	Links,
 	LiveReload,
@@ -15,16 +15,16 @@ export const links: LinksFunction = () => {
 	return [{ rel: 'stylesheet', href: tailwindStylesheetUrl }]
 }
 
-export const meta: MetaFunction = () => ({
-	charset: 'utf-8',
-	title: 'Remix Notes',
-	viewport: 'width=device-width,initial-scale=1',
-})
+export const meta: V2_MetaFunction = () => {
+	return [{ title: 'Remix Notes' }]
+}
 
 export default function App() {
 	return (
 		<html lang="en" className="h-full">
 			<head>
+				<meta charSet="utf-8" />
+				<meta name="viewport" content="width=device-width,initial-scale=1" />
 				<Meta />
 				<Links />
 			</head>

--- a/packages/example/exercises/02.styling/01.solution.links/remix.config.js
+++ b/packages/example/exercises/02.styling/01.solution.links/remix.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	cacheDirectory: './node_modules/.cache/remix',
 	ignoredRouteFiles: ['**/.*', '**/*.css', '**/*.test.{js,jsx,ts,tsx}'],
 	future: {
+		v2_meta: true,
 		unstable_postcss: true,
 	},
 }

--- a/packages/example/exercises/02.styling/02.solution.css-modules/app/root.tsx
+++ b/packages/example/exercises/02.styling/02.solution.css-modules/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from '@remix-run/node'
+import type { LinksFunction, V2_MetaFunction } from '@remix-run/node'
 import {
 	Links,
 	LiveReload,
@@ -15,16 +15,16 @@ export const links: LinksFunction = () => {
 	return [{ rel: 'stylesheet', href: tailwindStylesheetUrl }]
 }
 
-export const meta: MetaFunction = () => ({
-	charset: 'utf-8',
-	title: 'Remix Notes',
-	viewport: 'width=device-width,initial-scale=1',
-})
+export const meta: V2_MetaFunction = () => {
+	return [{ title: 'Remix Notes' }]
+}
 
 export default function App() {
 	return (
 		<html lang="en" className="h-full">
 			<head>
+				<meta charSet="utf-8" />
+				<meta name="viewport" content="width=device-width,initial-scale=1" />
 				<Meta />
 				<Links />
 			</head>

--- a/packages/example/exercises/02.styling/02.solution.css-modules/remix.config.js
+++ b/packages/example/exercises/02.styling/02.solution.css-modules/remix.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	cacheDirectory: './node_modules/.cache/remix',
 	ignoredRouteFiles: ['**/.*', '**/*.css', '**/*.test.{js,jsx,ts,tsx}'],
 	future: {
+		v2_meta: true,
 		unstable_postcss: true,
 	},
 }

--- a/packages/example/exercises/02.styling/03.problem.tailwind/app/root.tsx
+++ b/packages/example/exercises/02.styling/03.problem.tailwind/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from '@remix-run/node'
+import type { LinksFunction, V2_MetaFunction } from '@remix-run/node'
 import {
 	Links,
 	LiveReload,
@@ -15,16 +15,16 @@ export const links: LinksFunction = () => {
 	return [{ rel: 'stylesheet', href: tailwindStylesheetUrl }]
 }
 
-export const meta: MetaFunction = () => ({
-	charset: 'utf-8',
-	title: 'Remix Notes',
-	viewport: 'width=device-width,initial-scale=1',
-})
+export const meta: V2_MetaFunction = () => {
+	return [{ title: 'Remix Notes' }]
+}
 
 export default function App() {
 	return (
 		<html lang="en" className="h-full">
 			<head>
+				<meta charSet="utf-8" />
+				<meta name="viewport" content="width=device-width,initial-scale=1" />
 				<Meta />
 				<Links />
 			</head>

--- a/packages/example/exercises/02.styling/03.problem.tailwind/remix.config.js
+++ b/packages/example/exercises/02.styling/03.problem.tailwind/remix.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	cacheDirectory: './node_modules/.cache/remix',
 	ignoredRouteFiles: ['**/.*', '**/*.css', '**/*.test.{js,jsx,ts,tsx}'],
 	future: {
+		v2_meta: true,
 		unstable_postcss: true,
 	},
 }

--- a/packages/example/exercises/02.styling/03.solution.tailwind/app/root.tsx
+++ b/packages/example/exercises/02.styling/03.solution.tailwind/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from '@remix-run/node'
+import type { LinksFunction, V2_MetaFunction } from '@remix-run/node'
 import {
 	Links,
 	LiveReload,
@@ -15,16 +15,16 @@ export const links: LinksFunction = () => {
 	return [{ rel: 'stylesheet', href: tailwindStylesheetUrl }]
 }
 
-export const meta: MetaFunction = () => ({
-	charset: 'utf-8',
-	title: 'Remix Notes',
-	viewport: 'width=device-width,initial-scale=1',
-})
+export const meta: V2_MetaFunction = () => {
+	return [{ title: 'Remix Notes' }]
+}
 
 export default function App() {
 	return (
 		<html lang="en" className="h-full">
 			<head>
+				<meta charSet="utf-8" />
+				<meta name="viewport" content="width=device-width,initial-scale=1" />
 				<Meta />
 				<Links />
 			</head>

--- a/packages/example/exercises/02.styling/03.solution.tailwind/remix.config.js
+++ b/packages/example/exercises/02.styling/03.solution.tailwind/remix.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	cacheDirectory: './node_modules/.cache/remix',
 	ignoredRouteFiles: ['**/.*', '**/*.css', '**/*.test.{js,jsx,ts,tsx}'],
 	future: {
+		v2_meta: true,
 		unstable_postcss: true,
 	},
 }

--- a/packages/workshop-app/app/root.tsx
+++ b/packages/workshop-app/app/root.tsx
@@ -38,11 +38,7 @@ export const meta: V2_MetaFunction = ({
 }: {
 	data: SerializeFrom<typeof loader>
 }) => {
-	return [
-		{ charSet: 'utf-8' },
-		{ title: data?.workshopTitle },
-		{ name: 'viewport', content: 'width=device-width,initial-scale=1' },
-	]
+	return [{ title: data?.workshopTitle }]
 }
 
 export async function loader() {
@@ -84,6 +80,8 @@ export default function App() {
 			data-theme="light"
 		>
 			<head>
+				<meta charSet="utf-8" />
+				<meta name="viewport" content="width=device-width,initial-scale=1" />
 				<Meta />
 				<Links />
 			</head>


### PR DESCRIPTION
According to the docs, It is recommended to use normal `<meta>` tags inside of the root route for `viewport` and `charSet`.

All other routes use only title and we do not have any conflict.
There is no need to use merge Meta function.