### PR TITLE
fix: remove prose margin from list item first/last child

### DIFF
--- a/packages/workshop-app/tailwind.config.js
+++ b/packages/workshop-app/tailwind.config.js
@@ -1,6 +1,21 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 const colors = require('tailwindcss/colors')
 
+const removeProseMargin = {
+	'> ul > li > *:first-child': {
+		marginTop: 'unset',
+	},
+	'> ul > li > *:last-child': {
+		marginBottom: 'unset',
+	},
+	'> ol > li > *:first-child': {
+		marginTop: 'unset',
+	},
+	'> ol > li > *:last-child': {
+		marginBottom: 'unset',
+	},
+}
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
 	content: ['./app/**/*.{ts,tsx,jsx,js}', '../example/**/*.md'],
@@ -17,6 +32,14 @@ module.exports = {
 			},
 			colors: {
 				gray: colors.neutral,
+			},
+			typography: {
+				DEFAULT: { css: [removeProseMargin] },
+				sm: { css: [removeProseMargin] },
+				base: { css: [removeProseMargin] },
+				lg: { css: [removeProseMargin] },
+				xl: { css: [removeProseMargin] },
+				'2xl': { css: [removeProseMargin] },
 			},
 		},
 	},


### PR DESCRIPTION
I've used `unset` to reset the margin to its default

let me know if you want a different size and if you like to change other typography defaults