### PR TITLE
fix: add cache getDiffFiles, use --ignore-blank-lines

### DIFF
--- a/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
+++ b/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
@@ -191,7 +191,10 @@ export async function loader({ request, params }: DataFunctionArgs) {
 				return null
 			}),
 			problemApp && solutionApp
-				? getDiffFiles(problemApp, solutionApp).catch(e => {
+				? getDiffFiles(problemApp, solutionApp, {
+						request,
+						timings,
+				  }).catch(e => {
 						console.error(e)
 						return 'There was a problem generating the diff'
 				  })

--- a/packages/workshop-app/app/utils/diff.server.ts
+++ b/packages/workshop-app/app/utils/diff.server.ts
@@ -14,7 +14,7 @@ import {
 	type App,
 } from './apps.server'
 import { type Timings } from './timing.server'
-import { CacheEntry } from 'cachified'
+import { type CacheEntry } from 'cachified'
 
 const kcdshopTempDir = path.join(os.tmpdir(), 'kcdshop')
 

--- a/packages/workshop-app/app/utils/diff.server.ts
+++ b/packages/workshop-app/app/utils/diff.server.ts
@@ -284,10 +284,9 @@ export async function getDiffFilesImpl(app1: App, app2: App) {
 		.map(file => ({
 			//  prettier-ignore
 			status: (typesMap[file.type]??'unknown') as 'renamed'|'modified'|'deleted'|'added'|'unknown',
-			// always use forward separator for our README files
 			path: diffPathToRelative(
 				file.type === 'RenamedFile' ? file.pathBefore : file.path,
-			).replace(/\\/g, '/'),
+			),
 		}))
 		.filter(typedBoolean)
 }

--- a/packages/workshop-app/app/utils/diff.server.ts
+++ b/packages/workshop-app/app/utils/diff.server.ts
@@ -282,8 +282,8 @@ export async function getDiffFilesImpl(app1: App, app2: App) {
 
 	return parsed.files
 		.map(file => ({
-			//  prettier-ignore
-			status: (typesMap[file.type]??'unknown') as 'renamed'|'modified'|'deleted'|'added'|'unknown',
+			// prettier-ignore
+			status: (typesMap[file.type] ?? 'unknown') as 'renamed' | 'modified' | 'deleted' | 'added' | 'unknown',
 			path: diffPathToRelative(
 				file.type === 'RenamedFile' ? file.pathBefore : file.path,
 			),

--- a/packages/workshop-app/utils/cache.server.ts
+++ b/packages/workshop-app/utils/cache.server.ts
@@ -18,6 +18,7 @@ declare global {
 	var __playground_app_cache__: ReturnType<typeof getPlaygroundAppCache>
 	var __get_apps_cache__: ReturnType<typeof getAppsCache>
 	var __diff_code_cache__: ReturnType<typeof getDiffCodeCache>
+	var __diff_files_cache__: ReturnType<typeof getDiffFilesCache>
 	var __compiled_markdown_cache__: ReturnType<typeof getCompiledMarkdownCache>
 }
 
@@ -38,6 +39,9 @@ export const appsCache = (global.__get_apps_cache__ =
 
 export const diffCodeCache = (global.__diff_code_cache__ =
 	global.__diff_code_cache__ ?? getDiffCodeCache())
+
+export const diffFilesCache = (global.__diff_files_cache__ =
+	global.__diff_files_cache__ ?? getDiffFilesCache())
 
 export const compiledMarkdownCache = (global.__compiled_markdown_cache__ =
 	global.__compiled_markdown_cache__ ?? getCompiledMarkdownCache())
@@ -81,6 +85,13 @@ function getDiffCodeCache() {
 	const cache = new LRU<string, CacheEntry<string>>({ max: 1000 })
 	// @ts-expect-error it's fine
 	cache.name = 'DiffCodeCache'
+	return lruCacheAdapter(cache)
+}
+
+function getDiffFilesCache() {
+	const cache = new LRU<string, CacheEntry<string>>({ max: 1000 })
+	// @ts-expect-error it's fine
+	cache.name = 'DiffFilesCache'
 	return lruCacheAdapter(cache)
 }
 


### PR DESCRIPTION
add cache to `getDiffFiles` calls.
relevant files are always the same for a step.

fix this:

![diff](https://user-images.githubusercontent.com/3650909/232976109-aaa3a3c0-fb65-4424-b28a-1b15bbb89117.png)
