### PR TITLE
chore: `fetcher.type` will be removed in v2

### DIFF
--- a/packages/workshop-app/app/routes/launch-editor.tsx
+++ b/packages/workshop-app/app/routes/launch-editor.tsx
@@ -90,7 +90,7 @@ export function LaunchEditor({
 				}
 			}
 			case 'idle': {
-				if (fetcher.type === 'done') onUpdate?.('fetcher-done')
+				if (fetcher.data != null) onUpdate?.('fetcher-done')
 			}
 		}
 	}, [fetcher, onUpdate])


### PR DESCRIPTION

console warning:
```
REMIX FUTURE CHANGE: `fetcher.type` will be removed in v2. Please use `fetcher.state`, `fetcher.formData`, and `fetcher.data` to achieve the same UX.For instructions on making this change see https://remix.run/docs/en/v1.15.0/pages/v2#usefetcher
l
```

[Remix docs example](https://remix.run/docs/en/1.15.0/pages/v2#usefetcher)

```js
  // fetcher.type === "done"
  let isDone =
    fetcher.state === "idle" && fetcher.data != null;
```