### PR TITLE
chore: minore cleanup $exerciseNumber_.$stepNumber.$type

### DIFF
--- a/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
+++ b/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
@@ -148,8 +148,9 @@ export async function loader({ request, params }: DataFunctionArgs) {
 	}
 
 	async function getAppRunningState(a: App) {
-		if (a?.dev.type !== 'script')
+		if (a?.dev.type !== 'script') {
 			return { isRunning: false, portIsAvailable: null }
+		}
 		const isRunning = isAppRunning(a)
 		const portIsAvailable = isRunning
 			? null


### PR DESCRIPTION
resolves #41 

`).then(a => (isProblemApp(a) ? a : null))` and  `).then(a => (isSolutionApp(a) ? a : null))` are redundant here since `getExerciseApp` already filter for the type