### PR TITLE
chore: skip cache update when changing playground

### DIFF
--- a/packages/workshop-app/utils/apps.server.ts
+++ b/packages/workshop-app/utils/apps.server.ts
@@ -951,7 +951,7 @@ export async function setPlayground(srcDir: string) {
 	}
 
 	setPlaygroundActive = false
-	modifiedTimes.set(srcDir, Date.now())
+	modifiedTimes.set(destDir, Date.now())
 
 	const appName = await getAppName(srcDir)
 	await fsExtra.ensureDir(path.dirname(playgroundAppNameInfoPath))

--- a/packages/workshop-app/utils/apps.server.ts
+++ b/packages/workshop-app/utils/apps.server.ts
@@ -168,6 +168,9 @@ export function init() {
 		event: string,
 		filePath: string,
 	): Promise<void> {
+		if (setPlaygroundActive && filePath.includes('playground')) {
+			return
+		}
 		const apps = await getApps()
 		for (const app of apps) {
 			if (filePath.startsWith(app.fullPath)) {
@@ -910,7 +913,10 @@ export function getAppPageRoute(app: ExerciseStepApp) {
 	return `/${exerciseNumber}/${stepNumber}/${app.type}`
 }
 
+let setPlaygroundActive = false
+
 export async function setPlayground(srcDir: string) {
+	setPlaygroundActive = true
 	const { globby, isGitIgnored } = await import('globby')
 	const isIgnored = await isGitIgnored({ cwd: srcDir })
 	const destDir = path.join(getWorkshopRoot(), 'playground')
@@ -943,6 +949,9 @@ export async function setPlayground(srcDir: string) {
 	for (const fileToDelete of filesToDelete) {
 		await fsExtra.remove(path.join(destDir, fileToDelete))
 	}
+
+	setPlaygroundActive = false
+	modifiedTimes.set(srcDir, Date.now())
 
 	const appName = await getAppName(srcDir)
 	await fsExtra.ensureDir(path.dirname(playgroundAppNameInfoPath))

--- a/packages/workshop-app/utils/change-tracker.ts
+++ b/packages/workshop-app/utils/change-tracker.ts
@@ -22,6 +22,7 @@ export function getWatcher() {
 			'**/playwright-report/**',
 		],
 	})
+	global.__change_tracker_watcher__ = watcher
 	return watcher
 }
 


### PR DESCRIPTION
this is all we need to do to solve #46

should it be a `chore` or a `fix` ?