### PR TITLE
chore: clear repeated calls to getWorkshopRoot

### DIFF
--- a/packages/workshop-app/utils/apps.server.ts
+++ b/packages/workshop-app/utils/apps.server.ts
@@ -1009,5 +1009,3 @@ export function getRelativePath(filePath: string) {
 		.replace(playgroundPath, `playground${path.sep}`)
 		.replace(exercisesPath, '')
 }
-
-/* eslint no-shadow: [2, {hoist: "all"}] */


### PR DESCRIPTION
would you consider to enable `eslint` rules for no-shadow and such.