### PR TITLE
fix: getLanguage always return 'text' on Windows

### DIFF
--- a/packages/workshop-app/app/utils/diff.server.ts
+++ b/packages/workshop-app/app/utils/diff.server.ts
@@ -52,7 +52,9 @@ function getFileCodeblocks(
 	if (!file.chunks.length) {
 		return [`No changes`]
 	}
-	const filepath = file.type === 'RenamedFile' ? file.pathAfter : file.path
+	const filepath = diffPathToRelative(
+		file.type === 'RenamedFile' ? file.pathAfter : file.path,
+	)
 	const extension = path.extname(filepath).slice(1)
 	const lang = getLanguage(extension)
 	const pathToCopy = file.type === 'RenamedFile' ? file.pathBefore : file.path


### PR DESCRIPTION
`parseGitDiff` paths in windows are wrapped in double quote, so `path.extname(filepath).slice(1)` return `tsx"` instead of `tsx`

The extra double quote at the end made getLanguage fail to find the correct language.