### PR TITLE
fix: add missing export

### DIFF
--- a/packages/workshop-app/package.json
+++ b/packages/workshop-app/package.json
@@ -19,6 +19,10 @@
       "types": "./build/utils/apps.server.d.ts",
       "default": "./build/utils/apps.server.js"
     },
+    "./change-tracker": {
+      "types": "./build/utils/change-tracker.d.ts",
+      "default": "./build/utils/change-tracker.js"
+    },
     "./iframe-sync": {
       "types": "./build/utils/iframe-sync.d.ts",
       "default": "./build/utils/iframe-sync.js"


### PR DESCRIPTION

`change-tracker` is used by `testing-web-apps` during setup