### PR TITLE
fix: Set to Playground fails - EPERM: operation not permitted, copyfile

### DIFF
--- a/packages/workshop-app/app/routes/set-playground.tsx
+++ b/packages/workshop-app/app/routes/set-playground.tsx
@@ -16,6 +16,7 @@ import { getErrorMessage } from '~/utils/misc.tsx'
 import Icon from '~/components/icons.tsx'
 import { getDiffCode } from '~/utils/diff.server.ts'
 import { clsx } from 'clsx'
+import { showToast } from '~/components/toast.tsx'
 
 const setPlaygroundSchema = z.object({
 	appName: z.string(),
@@ -68,6 +69,22 @@ export function SetPlayground({
 	appName: string
 } & JSX.IntrinsicElements['button']) {
 	const fetcher = useFetcher<typeof action>()
+
+	useEffect(() => {
+		switch (fetcher.state) {
+			case 'loading': {
+				const error = fetcher.data?.status === 'error' ? fetcher.data.error : ''
+				if (error) {
+					showToast(document, {
+						title: 'Set Playground Error',
+						variant: 'Error',
+						content: error,
+					})
+				}
+			}
+		}
+	}, [fetcher])
+
 	return (
 		<fetcher.Form
 			action="/set-playground"
@@ -84,9 +101,6 @@ export function SetPlayground({
 					fetcher.data?.status === 'error' ? 'cursor-not-allowed' : null,
 				)}
 			/>
-			{fetcher.data?.status === 'error' ? (
-				<div className="error">{fetcher.data.error}</div>
-			) : null}
 		</fetcher.Form>
 	)
 }

--- a/packages/workshop-app/utils/process-manager.server.ts
+++ b/packages/workshop-app/utils/process-manager.server.ts
@@ -273,7 +273,12 @@ export function getProcesses() {
 export async function closeProcess(key: string) {
 	const proc = devProcesses.get(key)
 	if (proc) {
-		proc.process.kill()
+		if (process.platform === 'win32') {
+			const { execa } = await import('execa')
+			await execa('taskkill', ['/pid', String(proc.process.pid), '/f', '/t'])
+		} else {
+			proc.process.kill()
+		}
 		await stopPort(proc.port) // 🤷‍♂️
 		devProcesses.delete(key)
 	}


### PR DESCRIPTION
while testing remix v1.17 on `testing-web-apps` workshop.

I tripped by this issue when trying to 'Set To PLAYGROUND' while app from other exercise was already running.

```
EPERM: operation not permitted, copyfile
'C:\projects\kcd-apps\testing-web-apps\exercises\02.http-mocking\01.problem.setup\app\routes\resources+\create-host.tsx' --> C:\projects\kcd-apps\testing-web-apps\playground\app\routes\resources+\create-host.tsx'
```

## FIX
I propose to fix this issue with this patch cf0754d3cfb89b291a8942a9193c7bf39caea644
**noticed** that the app in the iframe flashes for split second, in the time it take to close the current app and kill the port before `setPlayground` can start copy the current app to the playground


## Screenshot before 6374a90c706decc719adff0dbe7fa3d9457a0e88
![error_on_form](https://github.com/epicweb-dev/kcdshop/assets/3650909/40d24f3f-0819-40e3-9ad6-76ffebdec029)

## Screenshot after 6374a90c706decc719adff0dbe7fa3d9457a0e88
![set-playground-error](https://github.com/epicweb-dev/kcdshop/assets/3650909/7714fdaa-f37e-43dc-a20e-93b4725216be)
