### PR TITLE
fix: wrong toast icons viewBox

### DIFF
--- a/packages/workshop-app/app/components/toast.tsx
+++ b/packages/workshop-app/app/components/toast.tsx
@@ -65,7 +65,7 @@ function BaseToast({
 									{ 'text-green-500': variantColor === 'green' },
 									{ 'text-blue-500': variantColor === 'blue' },
 								)}
-								viewBox="0 0 24 24"
+								size={24}
 								name={variant}
 								aria-hidden="true"
 							/>

--- a/packages/workshop-app/public/icons.svg
+++ b/packages/workshop-app/public/icons.svg
@@ -404,7 +404,7 @@
     </symbol>
 
     <symbol
-      id="Error" viewBox="0 0 16 16">
+      id="Error" viewBox="0 0 24 24">
       <g fill="none" strokeWidth="2" stroke="currentColor">
         <path
           strokeLinecap="round"
@@ -415,7 +415,7 @@
     </symbol>
 
     <symbol
-      id="Notify" viewBox="0 0 16 16">
+      id="Notify" viewBox="0 0 24 24">
       <g fill="none" strokeWidth="2" stroke="currentColor">
         <path
           strokeLinecap="round"
@@ -426,7 +426,7 @@
     </symbol>
 
     <symbol
-      id="Success" viewBox="0 0 16 16">
+      id="Success" viewBox="0 0 24 24">
       <g fill="none" strokeWidth="2" stroke="currentColor">
         <path
           strokeLinecap="round"


### PR DESCRIPTION
fix regression from 23274272e6872f4af3d2e28e7c20badaf7980e60

```diff
    <symbol
-      id="Error" viewBox="0 0 16 16">
+      id="Error" viewBox="0 0 24 24">
      <g fill="none" strokeWidth="2" stroke="currentColor">
        <path
          strokeLinecap="round"
```

```diff
    <symbol
-      id="Notify" viewBox="0 0 16 16">
+      id="Notify" viewBox="0 0 24 24">
      <g fill="none" strokeWidth="2" stroke="currentColor">
        <path
          strokeLinecap="round"
```

```diff
    <symbol
-      id="Success" viewBox="0 0 16 16">
+      id="Success" viewBox="0 0 24 24">
      <g fill="none" strokeWidth="2" stroke="currentColor">
        <path
          strokeLinecap="round"
```