### PR TITLE
fix: update prose line highlight padding and left border

### DIFF
--- a/packages/workshop-app/app/styles/app.css
+++ b/packages/workshop-app/app/styles/app.css
@@ -110,6 +110,21 @@ body {
 	padding-right: 0rem;
 }
 
+/**
+ keep it in separate css rule
+ has() is not supported in all browsers as of 2023-06-30
+*/
+.prose
+	pre:not([data-line-numbers='true']):not([data-lang='sh']):has(
+		[data-highlight]
+	) {
+	padding-left: 0rem;
+	padding-right: 0rem;
+}
+
+.prose
+	pre:not([data-line-numbers='true']):not([data-lang='sh'])
+	[data-highlight]:before,
 .prose
 	pre[data-line-numbers='true']:not([data-lang='sh'])
 	[data-line-number]:before {
@@ -123,6 +138,12 @@ body {
 	position: sticky;
 	left: 0;
 	background-color: var(--base00);
+}
+
+.prose
+	pre:not([data-line-numbers='true']):not([data-lang='sh'])
+	[data-highlight]:before {
+	content: ' ';
 }
 
 .prose pre[data-filename] {


### PR DESCRIPTION
fix highlight padding and left border on code block without line numbers

left border work for all browsers
`padding 0` work only for browsers that support css .has() which is 87.43% as of today

![pre](https://github.com/epicweb-dev/kcdshop/assets/3650909/29509616-d0c8-4bd7-9203-5fc08485e60a)
