### PR TITLE
fix: use thin scrollbar for mdx pre tag

### DIFF
--- a/packages/workshop-app/app/utils/mdx.tsx
+++ b/packages/workshop-app/app/utils/mdx.tsx
@@ -151,7 +151,14 @@ export function PreWithButtons({ children, ...props }: any) {
 				{buttons ? <OpenInEditor {...props} /> : null}
 				{showCopyButton ? <CopyButton /> : null}
 			</div>
-			<pre {...props} {...updateFilename()}>
+			<pre
+				{...props}
+				className={clsx(
+					'scrollbar-thin scrollbar-thumb-scrollbar',
+					props.className ?? '',
+				)}
+				{...updateFilename()}
+			>
 				{children}
 			</pre>
 		</div>
@@ -163,6 +170,15 @@ export const mdxComponents = {
 	// you can't put a <form> inside a <p> so we'll just use a div
 	// if this is a problem, then render the form outside of the MDX and update <LaunchEditor /> to reference that one instead or something.
 	p: (props: any) => <div {...props} />,
+	pre: (props: any) => (
+		<pre
+			{...props}
+			className={clsx(
+				'scrollbar-thin scrollbar-thumb-scrollbar',
+				props.className ?? '',
+			)}
+		/>
+	),
 	LaunchEditor,
 }
 


### PR DESCRIPTION
![thin-scrollbar](https://github.com/epicweb-dev/kcdshop/assets/3650909/e47adce6-5b3f-445f-9e52-2165e1174e54)
