### PR TITLE
feat: add notice on deployed version

### DIFF
--- a/packages/workshop-app/app/components/diff.tsx
+++ b/packages/workshop-app/app/components/diff.tsx
@@ -54,8 +54,8 @@ export function Diff({
 				}
 			>
 				{diff => (
-					<div className="flex w-full flex-col">
-						<div className="border-border h-14 border-b">
+					<div className="flex h-full w-full flex-col">
+						<div className="h-14 flex-shrink-0 border-b border-border">
 							<Form
 								onChange={e => submit(e.currentTarget)}
 								className="scrollbar-thin scrollbar-thumb-scrollbar flex h-full w-full items-center overflow-x-auto"
@@ -77,7 +77,7 @@ export function Diff({
 								/>
 							</Form>
 						</div>
-						<div className="scrollbar-thin scrollbar-thumb-scrollbar max-h-[calc(100vh-109px)] overflow-y-auto">
+						<div className="scrollbar-thin scrollbar-thumb-scrollbar flex-grow overflow-y-scroll">
 							{diff.diffCode ? (
 								<div>
 									<Accordion.Root className="w-full" type="multiple">

--- a/packages/workshop-app/app/root.tsx
+++ b/packages/workshop-app/app/root.tsx
@@ -127,7 +127,13 @@ export default function App() {
 				{ENV.KCDSHOP_DEPLOYED ? (
 					<div className="h-full pt-10">
 						<h6 className="fixed inset-0 z-10 flex h-10 items-center border-b border-border px-2 font-mono text-sm font-medium uppercase leading-tight">
-							Limited deployed version
+							<div>
+								Limited deployed version.{' '}
+								<a href={ENV.KCDSHOP_GITHUB_ROOT} className="underline">
+									Setup locally
+								</a>{' '}
+								to get the full experience.
+							</div>
 						</h6>
 						<Outlet />
 					</div>

--- a/packages/workshop-app/app/root.tsx
+++ b/packages/workshop-app/app/root.tsx
@@ -123,8 +123,17 @@ export default function App() {
 					}}
 				/>
 			</head>
-			<body className="scrollbar-thin scrollbar-thumb-scrollbar bg-background text-foreground h-full">
-				<Outlet />
+			<body className="scrollbar-thin scrollbar-thumb-scrollbar h-screen bg-background text-foreground">
+				{ENV.KCDSHOP_DEPLOYED ? (
+					<div className="h-full pt-10">
+						<h6 className="fixed inset-0 z-10 flex h-10 items-center border-b border-border px-2 font-mono text-sm font-medium uppercase leading-tight">
+							Limited deployed version
+						</h6>
+						<Outlet />
+					</div>
+				) : (
+					<Outlet />
+				)}
 				<ScrollRestoration />
 				<ElementScrollRestoration elementQuery="[data-restore-scroll='true']" />
 				<Scripts />

--- a/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber.tsx
+++ b/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber.tsx
@@ -117,12 +117,38 @@ export default function ExerciseNumberRoute() {
 				data-restore-scroll="true"
 				className="shadow-on-scrollbox scrollbar-thin scrollbar-thumb-scrollbar h-full w-full overflow-y-auto"
 			>
-				<article className="h-full w-full border-r border-border md:w-3/4 lg:w-2/3">
-					<div className="px-10 pt-16">
-						<h1 className="text-[6vw] font-extrabold leading-none">
-							{data.exercise.title}
-						</h1>
-						<div className="mt-8">
+				<article className="min-h-full w-full border-r border-border md:w-3/4 lg:w-2/3 flex flex-col justify-between">
+					<div>
+						<div className="px-10 pt-16">
+							<h1 className="text-[6vw] font-extrabold leading-none">
+								{data.exercise.title}
+							</h1>
+							<div className="mt-8">
+								<ButtonLink
+									to={firstExercisePath}
+									prefetch="intent"
+									varient="big"
+								>
+									Start Learning
+								</ButtonLink>
+							</div>
+						</div>
+						<div className="prose dark:prose-invert sm:prose-lg border-border mt-16 w-full max-w-none border-t px-10 pt-16">
+							{data.exercise.instructionsCode ? (
+								<Mdx
+									code={data.exercise?.instructionsCode}
+									components={{
+										h1: () => null,
+										pre: PreWithButtons,
+										// @ts-expect-error 🤷‍♂️ this is fine
+										Link,
+									}}
+								/>
+							) : (
+								'No instructions yet...'
+							)}
+						</div>
+						<div className="flex w-full items-center p-10 pb-16">
 							<ButtonLink
 								to={firstExercisePath}
 								prefetch="intent"
@@ -131,26 +157,6 @@ export default function ExerciseNumberRoute() {
 								Start Learning
 							</ButtonLink>
 						</div>
-					</div>
-					<div className="prose dark:prose-invert sm:prose-lg border-border mt-16 w-full max-w-none border-t px-10 pt-16">
-						{data.exercise.instructionsCode ? (
-							<Mdx
-								code={data.exercise?.instructionsCode}
-								components={{
-									h1: () => null,
-									pre: PreWithButtons,
-									// @ts-expect-error 🤷‍♂️ this is fine
-									Link,
-								}}
-							/>
-						) : (
-							'No instructions yet...'
-						)}
-					</div>
-					<div className="flex w-full items-center p-10 pb-16">
-						<ButtonLink to={firstExercisePath} prefetch="intent" varient="big">
-							Start Learning
-						</ButtonLink>
 					</div>
 					<div className="flex h-[52px] justify-center border-t border-border">
 						<EditFileOnGitHub

--- a/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber.tsx
+++ b/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber.tsx
@@ -112,12 +112,12 @@ export default function ExerciseNumberRoute() {
 		data.exercises[0]?.exerciseNumber.toString().padStart(2, '0') ?? '01'
 	const firstExercisePath = `${firstExerciseNumber}/problem`
 	return (
-		<main className="relative h-screen w-full">
+		<main className="relative w-full">
 			<div
 				data-restore-scroll="true"
 				className="shadow-on-scrollbox scrollbar-thin scrollbar-thumb-scrollbar h-full w-full overflow-y-auto"
 			>
-				<article className="border-border min-h-full w-full border-r md:w-3/4 lg:w-2/3">
+				<article className="h-full w-full border-r border-border md:w-3/4 lg:w-2/3">
 					<div className="px-10 pt-16">
 						<h1 className="text-[6vw] font-extrabold leading-none">
 							{data.exercise.title}

--- a/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
+++ b/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
@@ -540,8 +540,8 @@ export default function ExercisePartRoute() {
 
 	return (
 		<div className="flex flex-grow flex-col">
-			<div className="grid flex-grow grid-cols-1 lg:grid-cols-2">
-				<div className="border-border relative flex h-[50vh] min-h-[450px] lg:h-screen flex-grow flex-col justify-between border-r">
+			<div className="grid h-full flex-grow grid-cols-1 grid-rows-2 lg:grid-cols-2 lg:grid-rows-1">
+				<div className="relative col-span-1 row-span-1 flex h-full flex-col border-r border-border">
 					<h4 className="pl-10 font-mono text-sm font-medium uppercase leading-tight">
 						<div className="flex h-14 flex-wrap items-center justify-start gap-x-3 py-2">
 							<Link to={`/${titleBits.exerciseNumber}`}>
@@ -611,7 +611,7 @@ export default function ExercisePartRoute() {
 					</div>
 				</div>
 				<Tabs.Root
-					className="relative flex h-[50vh] min-h-[450px] lg:h-screen flex-col"
+					className="relative col-span-1 row-span-1 flex flex-col overflow-y-auto"
 					value={activeTab}
 					// intentionally no onValueChange here because the Link will trigger the
 					// change.
@@ -619,7 +619,7 @@ export default function ExercisePartRoute() {
 					{/* the scrollbar adds 8 pixels to the bottom of the list which looks
 					funny with the border, especially when most of the time the scrollbar
 					shouldn't show up anyway. So we hide that extra space with -8px margin-bottom */}
-					<Tabs.List className="scrollbar-thin scrollbar-thumb-scrollbar min-h-14 z-20 mb-[-8px] inline-flex h-14 overflow-x-scroll">
+					<Tabs.List className="scrollbar-thin scrollbar-thumb-scrollbar z-20 mb-[-8px] flex-shrink-0 overflow-x-scroll">
 						{tabs.map(tab => {
 							return (
 								<Tabs.Trigger
@@ -635,7 +635,7 @@ export default function ExercisePartRoute() {
 								>
 									<Link
 										id={`${tab}-tab`}
-										className="focus:bg-foreground/80 focus:text-background/80 outline-none"
+										className="h-14 outline-none focus:bg-foreground/80 focus:text-background/80"
 										preventScrollReset
 										prefetch="intent"
 										to={`?${withParam(
@@ -650,7 +650,7 @@ export default function ExercisePartRoute() {
 							)
 						})}
 					</Tabs.List>
-					<div className="border-border relative z-10 flex flex-grow flex-col border-t">
+					<div className="relative z-10 flex flex-grow flex-col overflow-y-auto border-t border-border">
 						<Tabs.Content
 							value="playground"
 							className="radix-state-inactive:hidden flex flex-grow items-center justify-center"
@@ -682,7 +682,7 @@ export default function ExercisePartRoute() {
 						</Tabs.Content>
 						<Tabs.Content
 							value="tests"
-							className="radix-state-inactive:hidden flex max-h-[calc(100vh-53px)] flex-grow items-start justify-center overflow-hidden"
+							className="flex flex-grow items-start justify-center overflow-hidden radix-state-inactive:hidden"
 						>
 							<Tests
 								appInfo={data.playground}
@@ -692,7 +692,7 @@ export default function ExercisePartRoute() {
 						</Tabs.Content>
 						<Tabs.Content
 							value="diff"
-							className="radix-state-inactive:hidden flex flex-grow items-start justify-center"
+							className="flex h-full flex-grow items-start justify-center radix-state-inactive:hidden"
 						>
 							<Diff diff={data.diff} allApps={data.allApps} />
 						</Tabs.Content>
@@ -797,7 +797,7 @@ function PlaygroundWindow({
 		)
 	return (
 		<div className="flex h-full w-full flex-col justify-between">
-			<div className="border-border flex h-14 items-center justify-start gap-1 border-b px-3">
+			<div className="flex h-14 flex-shrink-0 items-center justify-start gap-1 border-b border-border px-3">
 				{problemAppName ? (
 					<SetPlayground appName={problemAppName}>
 						{playgroundLinkedUI}

--- a/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.finished.tsx
+++ b/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.finished.tsx
@@ -108,10 +108,10 @@ export default function ExerciseFinished() {
 		.toString()
 		.padStart(2, '0')
 	return (
-		<main className="flex h-screen w-full flex-col">
+		<main className="flex w-full flex-col">
 			<div className="grid w-full flex-grow grid-cols-2 overflow-y-auto">
-				<div className="border-border flex flex-grow flex-col border-r border-t">
-					<h4 className="border-border border-b py-8 pl-[58px] font-mono text-sm font-medium uppercase leading-tight">
+				<div className="flex flex-grow flex-col border-r border-border">
+					<h4 className="border-b border-border py-[20.5px] pl-[58px] font-mono text-sm font-medium uppercase leading-none">
 						<Link to={`/${exerciseNumber}`} className="underline">
 							{`${exerciseNumber}. ${data.exercise.title}`}
 						</Link>
@@ -124,7 +124,7 @@ export default function ExerciseFinished() {
 					>
 						<Loading />
 					</iframe>
-					<div className="border-border flex h-16 justify-end border-t">
+					<div className="flex h-[52px] justify-end border-t border-border">
 						<NavChevrons prev={data.prevStepLink} next={data.nextStepLink} />
 					</div>
 				</div>

--- a/packages/workshop-app/app/routes/_app+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/_layout.tsx
@@ -85,7 +85,7 @@ export const headers: HeadersFunction = ({ loaderHeaders, parentHeaders }) => {
 
 export default function App() {
 	return (
-		<div className="flex min-h-screen">
+		<div className="flex h-full">
 			<div className="flex flex-grow">
 				<div className="flex flex-grow">
 					<Navigation />
@@ -151,7 +151,7 @@ function Navigation() {
 				variants={menuVariants}
 				animate={menuControls}
 			>
-				<div className="flex h-screen flex-col items-center justify-between">
+				<div className="flex h-full flex-col items-center justify-between">
 					<NavToggle
 						title={data.workshopTitle}
 						menuControls={menuControls}

--- a/packages/workshop-app/app/routes/_app+/finished.tsx
+++ b/packages/workshop-app/app/routes/_app+/finished.tsx
@@ -59,10 +59,10 @@ export default function ExerciseFinished() {
 		['entry.2123647600', data.workshopTitle],
 	])
 	return (
-		<main className="flex h-screen w-full flex-col">
+		<main className="flex w-full flex-col">
 			<div className="grid w-full flex-grow grid-cols-2 overflow-y-auto">
-				<div className="border-border flex flex-grow flex-col border-r border-t">
-					<h4 className="border-border border-b py-8 pl-[58px] font-mono text-sm font-medium uppercase leading-tight">
+				<div className="flex flex-grow flex-col border-r border-border">
+					<h4 className="border-b border-border py-[20.5px] pl-[58px] font-mono text-sm font-medium uppercase leading-none">
 						{`${data.workshopTitle} | Finished`}
 					</h4>
 					<iframe
@@ -72,7 +72,7 @@ export default function ExerciseFinished() {
 					>
 						<Loading />
 					</iframe>
-					<div className="border-border flex h-16 justify-end border-t">
+					<div className="flex h-[52px] justify-end border-t border-border">
 						<NavChevrons
 							prev={
 								data.prevStepLink

--- a/packages/workshop-app/app/routes/_app+/index.tsx
+++ b/packages/workshop-app/app/routes/_app+/index.tsx
@@ -89,12 +89,12 @@ export default function Index() {
 		</ul>
 	)
 	return (
-		<main className="relative h-screen w-full">
+		<main className="relative w-full">
 			<div
 				data-restore-scroll="true"
 				className="shadow-on-scrollbox scrollbar-thin scrollbar-thumb-scrollbar h-full w-full overflow-y-auto"
 			>
-				<article className="border-border min-h-full w-full border-r md:w-3/4 lg:w-2/3">
+				<article className="h-full w-full border-r border-border md:w-3/4 lg:w-2/3">
 					<div className="px-10 pt-16">
 						<h1 className="text-[6vw] font-extrabold leading-none">
 							{data.title}

--- a/packages/workshop-app/app/routes/_app+/index.tsx
+++ b/packages/workshop-app/app/routes/_app+/index.tsx
@@ -94,30 +94,32 @@ export default function Index() {
 				data-restore-scroll="true"
 				className="shadow-on-scrollbox scrollbar-thin scrollbar-thumb-scrollbar h-full w-full overflow-y-auto"
 			>
-				<article className="h-full w-full border-r border-border md:w-3/4 lg:w-2/3">
-					<div className="px-10 pt-16">
-						<h1 className="text-[6vw] font-extrabold leading-none">
-							{data.title}
-						</h1>
-						<div className="mt-8">{exerciseLinks}</div>
-					</div>
-					<div className="prose dark:prose-invert sm:prose-lg border-border mt-16 w-full max-w-none border-t px-10 pt-16">
-						{data.workshopReadme.code ? (
-							<Mdx
-								code={data.workshopReadme.code}
-								components={{
-									h1: () => null,
-									pre: PreWithButtons,
-									// @ts-expect-error 🤷‍♂️ this is fine
-									Link,
-								}}
-							/>
-						) : (
-							'No instructions yet...'
-						)}
-					</div>
-					<div className="mb-10 p-10">
-						{data.workshopReadme.code?.length > 500 ? exerciseLinks : null}
+				<article className="min-h-full w-full border-r border-border md:w-3/4 lg:w-2/3 flex flex-col justify-between">
+					<div>
+						<div className="px-10 pt-16">
+							<h1 className="text-[6vw] font-extrabold leading-none">
+								{data.title}
+							</h1>
+							<div className="mt-8">{exerciseLinks}</div>
+						</div>
+						<div className="prose dark:prose-invert sm:prose-lg border-border mt-16 w-full max-w-none border-t px-10 pt-16">
+							{data.workshopReadme.code ? (
+								<Mdx
+									code={data.workshopReadme.code}
+									components={{
+										h1: () => null,
+										pre: PreWithButtons,
+										// @ts-expect-error 🤷‍♂️ this is fine
+										Link,
+									}}
+								/>
+							) : (
+								'No instructions yet...'
+							)}
+						</div>
+						<div className="mb-10 p-10">
+							{data.workshopReadme.code?.length > 500 ? exerciseLinks : null}
+						</div>
 					</div>
 					<div className="flex h-[52px] justify-center border-t border-border">
 						<EditFileOnGitHub

--- a/packages/workshop-app/app/routes/set-playground.tsx
+++ b/packages/workshop-app/app/routes/set-playground.tsx
@@ -147,7 +147,7 @@ export function PlaygroundChooser({
 				<Select.Content
 					position="popper"
 					align="start"
-					className="z-20 max-h-[70vh] bg-black text-white"
+					className="z-20 max-h-[50vh] bg-black text-white lg:max-h-[70vh]"
 				>
 					<Select.ScrollUpButton className="flex h-5 cursor-default items-center justify-center ">
 						<Icon name="ChevronUp" />


### PR DESCRIPTION
closes #118 

![deployed](https://github.com/epicweb-dev/kcdshop/assets/3650909/f6f001a3-fb47-431b-b648-1e6f4ec7e57e)

This PR add fixed header on all pages when `ENV.KCDSHOP_DEPLOYED` is true.

I've managed to fix all scroll issues by using `h-screen` only in one place in the body. All other places use `h-full` if needed. The main exercises layout has been changed to a two-column grid with one row on large screens and one column with two rows on narrow screens. This change solves all scroll issues on diff views.”