### PR TITLE
fix: always render google form LTR

### DIFF
--- a/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.finished.tsx
+++ b/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.finished.tsx
@@ -120,7 +120,7 @@ export default function ExerciseFinished() {
 					<iframe
 						className="flex-grow bg-white pt-4"
 						title="Elaboration"
-						src={`https://docs.google.com/forms/d/e/1FAIpQLSf3o9xyjQepTlOTH5Z7ZwkeSTdXh6YWI_RGc9KiyD3oUN0p6w/viewform?${searchParams.toString()}`}
+						src={`https://docs.google.com/forms/d/e/1FAIpQLSf3o9xyjQepTlOTH5Z7ZwkeSTdXh6YWI_RGc9KiyD3oUN0p6w/viewform?${searchParams.toString()}&hl=en`}
 					>
 						<Loading />
 					</iframe>

--- a/packages/workshop-app/app/routes/_app+/finished.tsx
+++ b/packages/workshop-app/app/routes/_app+/finished.tsx
@@ -68,7 +68,7 @@ export default function ExerciseFinished() {
 					<iframe
 						className="flex-grow bg-white pt-4"
 						title="Elaboration"
-						src={`https://docs.google.com/forms/d/e/1FAIpQLSdRmj9p8-5zyoqRzxp3UpqSbC3aFkweXvvJIKes0a5s894gzg/viewform?${searchParams.toString()}`}
+						src={`https://docs.google.com/forms/d/e/1FAIpQLSdRmj9p8-5zyoqRzxp3UpqSbC3aFkweXvvJIKes0a5s894gzg/viewform?${searchParams.toString()}&hl=en`}
 					>
 						<Loading />
 					</iframe>


### PR DESCRIPTION
Google Forms automatically detects the language of the user’s browser and displays the form in that language, if it is supported. This includes displaying the form in a right-to-left (RTL) layout for languages that are written from right to left, such as Arabic and Hebrew.

since you form is in English, it should always renders left-to-right

this PR fix this issue by appending `&hl=en` to the form’s URL