### PR TITLE
fix: better easy full-page diff view access

### DIFF
--- a/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
+++ b/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
@@ -10,10 +10,10 @@ import {
 	Link,
 	isRouteErrorResponse,
 	useLoaderData,
+	useNavigate,
 	useRouteError,
 	useSearchParams,
 	type LinkProps,
-	useNavigate,
 } from '@remix-run/react'
 import { clsx } from 'clsx'
 import * as React from 'react'
@@ -645,6 +645,7 @@ export default function ExercisePartRoute() {
 	}, [searchParams, previewAppUrl])
 
 	const titleBits = pageTitle(data)
+	const [altDown, setAltDown] = useState(false)
 	const navigate = useNavigate()
 
 	// when alt is held down, the diff tab should open to the full-page diff view
@@ -654,9 +655,10 @@ export default function ExercisePartRoute() {
 		app2: data.solution?.name ?? '',
 	})}`
 
-	const handleDiffClickWithAlt = React.useCallback(
+	const handleDiffTabClick = React.useCallback(
 		(event: React.MouseEvent<HTMLAnchorElement>) => {
-			if (event.altKey) {
+			setAltDown(event.altKey)
+			if (event.altKey && !event.ctrlKey && !event.shiftKey && !event.metaKey) {
 				event.preventDefault()
 				navigate(altDiffUrl)
 			}
@@ -765,12 +767,16 @@ export default function ExercisePartRoute() {
 										className="h-14 outline-none focus:bg-foreground/80 focus:text-background/80"
 										preventScrollReset
 										prefetch="intent"
-										onClick={handleDiffClickWithAlt}
-										to={`?${withParam(
-											searchParams,
-											'preview',
-											tab === 'playground' ? null : tab,
-										)}`}
+										onClickCapture={handleDiffTabClick}
+										to={
+											tab === 'diff' && altDown
+												? altDiffUrl
+												: `?${withParam(
+														searchParams,
+														'preview',
+														tab === 'playground' ? null : tab,
+												  )}`
+										}
 									>
 										{tab}
 									</Link>

--- a/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
+++ b/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
@@ -648,6 +648,16 @@ export default function ExercisePartRoute() {
 	const [altDown, setAltDown] = useState(false)
 	const navigate = useNavigate()
 
+	React.useEffect(() => {
+		const set = (e: KeyboardEvent) => setAltDown(e.altKey)
+		document.addEventListener('keydown', set)
+		document.addEventListener('keyup', set)
+		return () => {
+			document.removeEventListener('keyup', set)
+			document.removeEventListener('keydown', set)
+		}
+	}, [])
+
 	// when alt is held down, the diff tab should open to the full-page diff view
 	// between the problem and solution (this is more for the instructor than the student)
 	const altDiffUrl = `/diff?${new URLSearchParams({
@@ -655,16 +665,12 @@ export default function ExercisePartRoute() {
 		app2: data.solution?.name ?? '',
 	})}`
 
-	const handleDiffTabClick = React.useCallback(
-		(event: React.MouseEvent<HTMLAnchorElement>) => {
-			setAltDown(event.altKey)
-			if (event.altKey && !event.ctrlKey && !event.shiftKey && !event.metaKey) {
-				event.preventDefault()
-				navigate(altDiffUrl)
-			}
-		},
-		[navigate, altDiffUrl],
-	)
+	function handleDiffTabClick(event: React.MouseEvent<HTMLAnchorElement>) {
+		if (event.altKey && !event.ctrlKey && !event.shiftKey && !event.metaKey) {
+			event.preventDefault()
+			navigate(altDiffUrl)
+		}
+	}
 
 	return (
 		<div className="flex flex-grow flex-col">
@@ -767,7 +773,7 @@ export default function ExercisePartRoute() {
 										className="h-14 outline-none focus:bg-foreground/80 focus:text-background/80"
 										preventScrollReset
 										prefetch="intent"
-										onClickCapture={handleDiffTabClick}
+										onClick={handleDiffTabClick}
 										to={
 											tab === 'diff' && altDown
 												? altDiffUrl

--- a/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
+++ b/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber_.$stepNumber.$type.tsx
@@ -13,6 +13,7 @@ import {
 	useRouteError,
 	useSearchParams,
 	type LinkProps,
+	useNavigate,
 } from '@remix-run/react'
 import { clsx } from 'clsx'
 import * as React from 'react'
@@ -644,17 +645,7 @@ export default function ExercisePartRoute() {
 	}, [searchParams, previewAppUrl])
 
 	const titleBits = pageTitle(data)
-	const [altDown, setAltDown] = React.useState(false)
-
-	React.useEffect(() => {
-		const set = (e: KeyboardEvent) => setAltDown(e.altKey)
-		document.addEventListener('keydown', set)
-		document.addEventListener('keyup', set)
-		return () => {
-			document.removeEventListener('keyup', set)
-			document.removeEventListener('keydown', set)
-		}
-	}, [])
+	const navigate = useNavigate()
 
 	// when alt is held down, the diff tab should open to the full-page diff view
 	// between the problem and solution (this is more for the instructor than the student)
@@ -662,6 +653,16 @@ export default function ExercisePartRoute() {
 		app1: data.problem?.name ?? '',
 		app2: data.solution?.name ?? '',
 	})}`
+
+	const handleDiffClickWithAlt = React.useCallback(
+		(event: React.MouseEvent<HTMLAnchorElement>) => {
+			if (event.altKey) {
+				event.preventDefault()
+				navigate(altDiffUrl)
+			}
+		},
+		[navigate, altDiffUrl],
+	)
 
 	return (
 		<div className="flex flex-grow flex-col">
@@ -764,15 +765,12 @@ export default function ExercisePartRoute() {
 										className="h-14 outline-none focus:bg-foreground/80 focus:text-background/80"
 										preventScrollReset
 										prefetch="intent"
-										to={
-											tab === 'diff' && altDown
-												? altDiffUrl
-												: `?${withParam(
-														searchParams,
-														'preview',
-														tab === 'playground' ? null : tab,
-												  )}`
-										}
+										onClick={handleDiffClickWithAlt}
+										to={`?${withParam(
+											searchParams,
+											'preview',
+											tab === 'playground' ? null : tab,
+										)}`}
 									>
 										{tab}
 									</Link>


### PR DESCRIPTION
@kentcdodds , your previous approach can trigger 'Save As' dialog in some browsers / operating system, when clicking a link when Alt is down.

Using useState to check for alt can be tricky since it is not a synchronous function. React click handler can run before useState update altDown value.

this PR improve the use of Alt to navigate to full-page diff view.
follow-up to 9bc0245a6d8785474b80c5b8afdb34796d0a2123

with the code in this PR we only check if Alt is down when the link clicked, only if the Alt is down we navigate to `full-page diff`

