### PR TITLE
feat: open relevant file on first diff line

### DIFF
--- a/packages/workshop-app/app/components/touched-files.tsx
+++ b/packages/workshop-app/app/components/touched-files.tsx
@@ -97,7 +97,9 @@ function TouchedFiles() {
 													{diffFiles.length > 1 && !ENV.KCDSHOP_DEPLOYED ? (
 														<div className="mb-2 border-b border-b-gray-50 border-opacity-50 pb-2 font-sans">
 															<LaunchEditor
-																appFile={diffFiles.map(file => file.path)}
+																appFile={diffFiles.map(
+																	file => `${file.path},${file.line},1`,
+																)}
 																appName="playground"
 																onUpdate={handleLaunchUpdate}
 															>
@@ -108,8 +110,7 @@ function TouchedFiles() {
 													{diffFiles.map(file => (
 														<li key={file.path} data-state={file.status}>
 															<LaunchEditor
-																appFile={file.path}
-																line={file.line}
+																appFile={`${file.path},${file.line},1`}
 																appName={
 																	ENV.KCDSHOP_DEPLOYED
 																		? data.problem?.name ?? 'playground'

--- a/packages/workshop-app/app/components/touched-files.tsx
+++ b/packages/workshop-app/app/components/touched-files.tsx
@@ -109,6 +109,7 @@ function TouchedFiles() {
 														<li key={file.path} data-state={file.status}>
 															<LaunchEditor
 																appFile={file.path}
+																line={file.line}
 																appName={
 																	ENV.KCDSHOP_DEPLOYED
 																		? data.problem?.name ?? 'playground'

--- a/packages/workshop-app/app/utils/launch-editor.server.ts
+++ b/packages/workshop-app/app/utils/launch-editor.server.ts
@@ -270,7 +270,7 @@ function guessEditor() {
 }
 
 let _childProcess: ReturnType<typeof child_process.spawn> | null = null
-type Result = { status: 'success' } | { status: 'error'; error: string }
+export type Result = { status: 'success' } | { status: 'error'; error: string }
 export async function launchEditor(
 	pathList: string[] | string,
 	lineNumber?: number,


### PR DESCRIPTION
closes #131

this PR handle opening single file from `Relevant Files` dropdown on the line near the first diff in the file.

if you want to do the same for `Open All Files` we will have to modify `launchEditor` to spawn separate child process for each file.
I did not managed to launch multiple file in specific line from single command from windows terminal.
I am not sure that this is safe to do without testing
