### PR TITLE
Fix an issue with the file path on Windows systems

### DIFF
--- a/packages/workshop-app/app/utils/diff.server.ts
+++ b/packages/workshop-app/app/utils/diff.server.ts
@@ -25,8 +25,8 @@ const isDeployed = ENV.KCDSHOP_DEPLOYED
 const diffTmpDir = path.join(kcdshopTempDir, 'diff')
 
 function diffPathToRelative(filePath: string) {
-	if (filePath.startsWith('a/') || filePath.startsWith('b/')) {
-		filePath = filePath.slice(2)
+	if (filePath.startsWith('"a/') || filePath.startsWith('"b/')) {
+		filePath = filePath.slice(3)
 	}
 	const normalizedPath = path.normalize(filePath).replace(/^("|')|("|')$/g, '')
 


### PR DESCRIPTION
Hey Kent,

here is a fix for "Files opened from the 'File' menu are empty" on Discord. It works for me without any side effects so far, but I'll leave it to you to look into it more closely.

jokele