### PR TITLE
Still an issue with the Windows path

### DIFF
--- a/packages/workshop-app/app/utils/diff.server.ts
+++ b/packages/workshop-app/app/utils/diff.server.ts
@@ -25,10 +25,11 @@ const isDeployed = ENV.KCDSHOP_DEPLOYED
 const diffTmpDir = path.join(kcdshopTempDir, 'diff')
 
 function diffPathToRelative(filePath: string) {
-	if (filePath.startsWith('a/') || filePath.startsWith('b/')) {
-		filePath = filePath.slice(2)
+
+	let normalizedPath = path.normalize(filePath).replace(/^("|')|("|')$/g, '')
+	if (normalizedPath.startsWith('a/') || normalizedPath.startsWith('b/')) {
+		normalizedPath = normalizedPath.slice(2)
 	}
-	const normalizedPath = path.normalize(filePath).replace(/^("|')|("|')$/g, '')
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [workshopRootDirname, appId, id, ...relativePath] = normalizedPath

--- a/packages/workshop-app/app/utils/diff.server.ts
+++ b/packages/workshop-app/app/utils/diff.server.ts
@@ -27,7 +27,7 @@ const diffTmpDir = path.join(kcdshopTempDir, 'diff')
 function diffPathToRelative(filePath: string) {
 
 	let normalizedPath = path.normalize(filePath).replace(/^("|')|("|')$/g, '')
-	if (normalizedPath.startsWith('a\\') || normalizedPath.startsWith('b\\')) {
+	if (normalizedPath.startsWith('a\\') || normalizedPath.startsWith('b\\') || normalizedPath.startsWith('a/') || normalizedPath.startsWith('b/')) {
 		normalizedPath = normalizedPath.slice(2)
 	}
 

--- a/packages/workshop-app/app/utils/diff.server.ts
+++ b/packages/workshop-app/app/utils/diff.server.ts
@@ -27,7 +27,7 @@ const diffTmpDir = path.join(kcdshopTempDir, 'diff')
 function diffPathToRelative(filePath: string) {
 
 	let normalizedPath = path.normalize(filePath).replace(/^("|')|("|')$/g, '')
-	if (normalizedPath.startsWith('a/') || normalizedPath.startsWith('b/')) {
+	if (normalizedPath.startsWith('a\\') || normalizedPath.startsWith('b\\')) {
 		normalizedPath = normalizedPath.slice(2)
 	}
 


### PR DESCRIPTION
@kentcdodds 

I really hate these weired Windows paths. I've installed the new package, but because "path.normalize" changes "/" to "\\" on Windows systems, the check of "b/" and "a/" doesn't work anymore.

Because I don't know, if you use "a/" and "b/" on Unix systems as well, I extended the check, so all four options are checked now.

if (normalizedPath.startsWith('a\\\\') || normalizedPath.startsWith('b\\\\') || normalizedPath.startsWith('a/') || normalizedPath.startsWith('b/')) {...}

