### PR TITLE
Clamp the main page heading size to avoid overblow

### DIFF
--- a/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber.tsx
+++ b/packages/workshop-app/app/routes/_app+/_exercises+/$exerciseNumber.tsx
@@ -131,7 +131,7 @@ export default function ExerciseNumberRoute() {
 				className="shadow-on-scrollbox flex w-full flex-1 flex-col gap-12 overflow-y-scroll border-border px-3 py-4 pt-6 scrollbar-thin scrollbar-thumb-scrollbar md:px-10 md:py-12 md:pt-16"
 			>
 				<div>
-					<h1 className="text-[6vw] font-extrabold leading-none">
+					<h1 className="text-[clamp(3rem,6vw,8.5rem)] font-extrabold leading-none">
 						{data.exercise.title}
 					</h1>
 				</div>

--- a/packages/workshop-app/app/routes/_app+/index.tsx
+++ b/packages/workshop-app/app/routes/_app+/index.tsx
@@ -128,7 +128,7 @@ export default function Index() {
 				className="shadow-on-scrollbox flex w-full flex-1 flex-col gap-12 overflow-y-scroll border-border px-3 py-4 pt-6 scrollbar-thin scrollbar-thumb-scrollbar md:px-10 md:py-12 md:pt-16"
 			>
 				<div>
-					<h1 className="px-10 text-[6vw] font-extrabold leading-none">
+					<h1 className="px-10 text-[clamp(3rem,6vw,8.5rem)] font-extrabold leading-none">
 						{data.title}
 					</h1>
 				</div>


### PR DESCRIPTION
Avoids this happening on large screens:

![CleanShot 2024-01-16 at 07 44 27@2x](https://github.com/epicweb-dev/kcdshop/assets/485747/5f07fae3-c1b1-4bdb-b1ac-0e78e5cf59bf)

Instead, the font size stops growing if `6vw` reaches `8.5rem` (which is still BIG and keeps the same overall design vibe of big headline).

Same on smaller screens, text size will be clamped to a minimum of `3rem`.

CSS `clamp()` is broadly supported across browsers:

![CleanShot 2024-01-16 at 07 46 13@2x](https://github.com/epicweb-dev/kcdshop/assets/485747/965b7595-fae1-41a5-9abd-8461164bb84b)
