### PR TITLE
chore: restore project level config for now

### DIFF
--- a/packages/workshop-presence/package.json
+++ b/packages/workshop-presence/package.json
@@ -38,6 +38,15 @@
     "url": "https://github.com/epicweb-dev/kcdshop.git",
     "directory": "packages/presence"
   },
+  "nx": {
+    "targets": {
+      "nx-release-publish": {
+        "options": {
+          "packageRoot": "publish/{projectRoot}"
+        }
+      }
+    }
+  },
   "exports": {
     "./package.json": "./package.json",
     "./presence.server": {

--- a/packages/workshop-utils/package.json
+++ b/packages/workshop-utils/package.json
@@ -164,5 +164,14 @@
     "type": "git",
     "url": "https://github.com/epicweb-dev/kcdshop.git",
     "directory": "packages/workshop-utils"
+  },
+  "nx": {
+    "targets": {
+      "nx-release-publish": {
+        "options": {
+          "packageRoot": "publish/{projectRoot}"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Can be removed again once https://github.com/nrwl/nx/pull/21719 is released

The config is only needed in cases where a project only has a package.json (and no project.json). The workshop-app project has a project.json so doesn't need the additional config.

Verified all three projects are correct:

<img width="771" alt="image" src="https://github.com/epicweb-dev/kcdshop/assets/900523/64a9ca13-b7f9-4992-a84e-26ff90bd7acf">

<img width="738" alt="image" src="https://github.com/epicweb-dev/kcdshop/assets/900523/14fcd899-19eb-4ec7-8229-e6666bef9bf9">

<img width="779" alt="image" src="https://github.com/epicweb-dev/kcdshop/assets/900523/ffb4af13-6383-4d3b-9211-c0ff9f103957">

