### PR TITLE
chore(build): kcdshop depends on workshop-app

### DIFF
--- a/project.json
+++ b/project.json
@@ -1,10 +1,14 @@
 {
   "name": "kcdshop",
   "$schema": "node_modules/nx/schemas/project-schema.json",
-  "implicitDependencies": ["@kentcdodds/workshop-app"],
   "targets": {
     "build": {
-      "command": "nx run-many --target build --parallel --projects @kentcdodds/workshop-app,@kentcdodds/workshop-utils,@kentcdodds/workshop-presence"
+      "executor": "nx:noop",
+      "dependsOn": [
+        "@kentcdodds/workshop-app:build",
+        "@kentcdodds/workshop-utils",
+        "@kentcdodds/workshop-presence"
+      ]
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/project.json
+++ b/project.json
@@ -6,8 +6,8 @@
       "executor": "nx:noop",
       "dependsOn": [
         "@kentcdodds/workshop-app:build",
-        "@kentcdodds/workshop-utils",
-        "@kentcdodds/workshop-presence"
+        "@kentcdodds/workshop-utils:build",
+        "@kentcdodds/workshop-presence:build"
       ]
     },
     "lint": {

--- a/project.json
+++ b/project.json
@@ -1,6 +1,7 @@
 {
   "name": "kcdshop",
   "$schema": "node_modules/nx/schemas/project-schema.json",
+  "implicitDependencies": ["@kentcdodds/workshop-app"],
   "targets": {
     "build": {
       "command": "nx run-many --target build --parallel --projects @kentcdodds/workshop-app,@kentcdodds/workshop-utils,@kentcdodds/workshop-presence"


### PR DESCRIPTION
This should make it so that `@kentcdodds/workshop-app:build` is run before `kcdshop:build` and you don't get this error any more:

```
[Error: [remix] ENOENT: no such file or directory, open '/home/runner/work/kcdshop/kcdshop/packages/workshop-app/build/client/.vite/manifest.json']
```