### PR TITLE
Update workshop-presence README.md

### DIFF
--- a/packages/workshop-presence/README.md
+++ b/packages/workshop-presence/README.md
@@ -4,7 +4,7 @@ Welcome to the party, pal!
 
 This is a [Partykit](https://partykit.io) project, which lets you create real-time collaborative applications with minimal coding effort.
 
-[`server.ts`](./src/server.ts) is the server-side code, which is responsible for handling WebSocket events and HTTP requests. [`client.ts`](./src/client.ts) is the client-side code, which connects to the server and listens for events.
+[`server.ts`](./src/server.ts) is the server-side code, which is responsible for handling WebSocket events and HTTP requests. [`presence.tsx`](../workshop-app/app/utils/presence.tsx) is the client-side code, which connects to the server and listens for events.
 
 You can start developing by running `npm run dev` and opening [http://localhost:1999](http://localhost:1999) in your browser. When you're ready, you can deploy your application on to the PartyKit cloud with `npm run deploy`.
 


### PR DESCRIPTION
The `client.ts` file no longer exists. Point the README to the correct file.

- [x] Tested link is now correct. 