### PR TITLE
Link frontend requests to backend traces

### DIFF
--- a/packages/workshop-app/app/entry.client.tsx
+++ b/packages/workshop-app/app/entry.client.tsx
@@ -1,7 +1,8 @@
 import { hydrateRoot } from 'react-dom/client'
 import { HydratedRouter } from 'react-router/dom'
-import { init as initMonitoring } from './utils/monitoring.client'
+import { init as initMonitoring, setupRequestCorrelation } from './utils/monitoring.client'
 
 initMonitoring()
+setupRequestCorrelation()
 
 hydrateRoot(document, <HydratedRouter />)

--- a/packages/workshop-app/app/utils/monitoring.client.ts
+++ b/packages/workshop-app/app/utils/monitoring.client.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react-router'
+import { generateCorrelationId, setCorrelationId, getCorrelationId, CORRELATION_ID_HEADER } from './request-correlation'
 
 export function init() {
 	if (!ENV.EPICSHOP_IS_PUBLISHED) return
@@ -16,6 +17,20 @@ export function init() {
 					return null
 				}
 			}
+			
+			// Add correlation ID to event context
+			const correlationId = getCorrelationId()
+			if (correlationId) {
+				event.extra = {
+					...event.extra,
+					correlationId,
+				}
+				event.tags = {
+					...event.tags,
+					correlationId,
+				}
+			}
+			
 			return event
 		},
 		integrations: [
@@ -26,4 +41,26 @@ export function init() {
 		replaysSessionSampleRate: 0.1,
 		replaysOnErrorSampleRate: 1.0,
 	})
+}
+
+// Set up request correlation for React Router requests
+export function setupRequestCorrelation() {
+	if (!ENV.EPICSHOP_IS_PUBLISHED) return
+	
+	// Intercept React Router requests by patching fetch
+	const originalFetch = window.fetch
+	window.fetch = function(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+		const correlationId = generateCorrelationId()
+		setCorrelationId(correlationId)
+		
+		const headers = new Headers(init?.headers)
+		headers.set(CORRELATION_ID_HEADER, correlationId)
+		
+		const newInit = {
+			...init,
+			headers,
+		}
+		
+		return originalFetch(input, newInit)
+	}
 }

--- a/packages/workshop-app/app/utils/request-correlation.ts
+++ b/packages/workshop-app/app/utils/request-correlation.ts
@@ -1,0 +1,39 @@
+import { createId } from '@paralleldrive/cuid2'
+
+// Header name for request correlation
+export const CORRELATION_ID_HEADER = 'x-correlation-id'
+
+// Generate a unique correlation ID
+export function generateCorrelationId(): string {
+	return createId()
+}
+
+// Store correlation ID in context (client-side)
+let currentCorrelationId: string | null = null
+
+export function setCorrelationId(id: string): void {
+	currentCorrelationId = id
+}
+
+export function getCorrelationId(): string | null {
+	return currentCorrelationId
+}
+
+export function clearCorrelationId(): void {
+	currentCorrelationId = null
+}
+
+// Context for storing correlation ID during request processing (server-side)
+export const requestCorrelationContext = new Map<string, string>()
+
+export function setRequestCorrelationId(requestId: string, correlationId: string): void {
+	requestCorrelationContext.set(requestId, correlationId)
+}
+
+export function getRequestCorrelationId(requestId: string): string | null {
+	return requestCorrelationContext.get(requestId) || null
+}
+
+export function clearRequestCorrelationId(requestId: string): void {
+	requestCorrelationContext.delete(requestId)
+}

--- a/packages/workshop-app/server/index.ts
+++ b/packages/workshop-app/server/index.ts
@@ -195,6 +195,25 @@ if (!ENV.EPICSHOP_DEPLOYED) {
 	})
 }
 
+// Add correlation ID middleware before React Router handler
+app.use((req, res, next) => {
+	const correlationId = req.headers['x-correlation-id'] as string
+	if (correlationId && ENV.EPICSHOP_IS_PUBLISHED) {
+		// Add correlation ID to current Sentry scope
+		import('@sentry/react-router').then(({ withScope }) => {
+			withScope((scope) => {
+				scope.setTag('correlationId', correlationId)
+				scope.setExtra('correlationId', correlationId)
+				scope.setContext('correlation', {
+					id: correlationId,
+					timestamp: new Date().toISOString(),
+				})
+			})
+		})
+	}
+	next()
+})
+
 app.all(
 	'*splat',
 	createRequestHandler({


### PR DESCRIPTION
Implement request correlation to link frontend and backend errors in Sentry for improved tracing and diagnosis.