### PR TITLE
Fix divider drag event in iframe

### DIFF
--- a/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
@@ -331,7 +331,10 @@ export default function ExercisePartRoute({
 
 		function handleMove(clientX: number) {
 			// Safety check: ensure user is still dragging
-			if (!dragging) return
+			if (!dragging) {
+				cleanup()
+				return
+			}
 
 			const relativeX = clientX - rect.left
 			const percent = (relativeX / rect.width) * 100


### PR DESCRIPTION
Enable the draggable vertical divider to function correctly when dragging over iframes.

Previously, `mousemove` events were lost when dragging the divider quickly over embedded iframes, as iframes capture these events. This PR resolves the issue by temporarily setting `pointer-events: none` on all iframes during a drag operation and using window-level event listeners, ensuring the drag state is maintained globally. Additionally, necessary layout files were restored/created to resolve build and type-checking errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-643f0260-a43e-4e9f-91c7-f76945293b53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-643f0260-a43e-4e9f-91c7-f76945293b53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

