### PR TITLE
Include warm cache in docker image

### DIFF
--- a/packages/workshop-utils/src/data-storage.server.ts
+++ b/packages/workshop-utils/src/data-storage.server.ts
@@ -7,14 +7,9 @@ import { getEnv } from './init-env.js'
 const APP_NAME = 'epicshop'
 const FILE_NAME = 'data.json'
 
-const DEFAULT_EPICSHOP_HOME_DIR = path.join(os.homedir(), '.epicshop')
-
 function getConfiguredHomeDir() {
 	const envHomeDir = getEnv().EPICSHOP_HOME_DIR
-	if (!envHomeDir || envHomeDir === DEFAULT_EPICSHOP_HOME_DIR) {
-		return null
-	}
-	return envHomeDir
+	return envHomeDir ? envHomeDir : null
 }
 
 export function resolvePrimaryDir() {

--- a/packages/workshop-utils/src/data-storage.test.ts
+++ b/packages/workshop-utils/src/data-storage.test.ts
@@ -1,6 +1,13 @@
 import { promises as fs } from 'node:fs'
 import * as os from 'node:os'
 import { test, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const envRef = { homeDir: '/mock/home/.epicshop' }
+
+vi.mock('./init-env.js', () => ({
+	getEnv: () => ({ EPICSHOP_HOME_DIR: envRef.homeDir }),
+}))
+
 import {
 	resolvePrimaryDir,
 	resolveCacheDir,
@@ -29,6 +36,7 @@ const mockOs = vi.mocked(os)
 beforeEach(() => {
 	vi.clearAllMocks()
 	mockOs.homedir.mockReturnValue('/mock/home')
+	envRef.homeDir = '/mock/home/.epicshop'
 })
 
 afterEach(() => {
@@ -75,6 +83,7 @@ function withPlatform(
 }
 
 test('resolvePrimaryDir returns correct path for darwin', () => {
+	envRef.homeDir = ''
 	using _ = withPlatform('darwin')
 
 	const result = resolvePrimaryDir()
@@ -82,6 +91,7 @@ test('resolvePrimaryDir returns correct path for darwin', () => {
 })
 
 test('resolvePrimaryDir returns correct path for win32', () => {
+	envRef.homeDir = ''
 	using _ = withPlatform('win32', {
 		LOCALAPPDATA: undefined,
 		APPDATA: undefined,
@@ -92,6 +102,7 @@ test('resolvePrimaryDir returns correct path for win32', () => {
 })
 
 test('resolvePrimaryDir returns correct path for linux', () => {
+	envRef.homeDir = ''
 	using _ = withPlatform('linux', {
 		XDG_STATE_HOME: undefined,
 	})
@@ -101,6 +112,7 @@ test('resolvePrimaryDir returns correct path for linux', () => {
 })
 
 test('resolvePrimaryDir uses EPICSHOP_HOME_DIR override when provided', () => {
+	envRef.homeDir = '/custom/epicshop'
 	using _ = withPlatform('linux', {
 		EPICSHOP_HOME_DIR: '/custom/epicshop',
 	})
@@ -110,6 +122,7 @@ test('resolvePrimaryDir uses EPICSHOP_HOME_DIR override when provided', () => {
 })
 
 test('resolveCacheDir returns correct path for darwin', () => {
+	envRef.homeDir = ''
 	using _ = withPlatform('darwin')
 
 	const result = resolveCacheDir()
@@ -117,6 +130,7 @@ test('resolveCacheDir returns correct path for darwin', () => {
 })
 
 test('resolveCacheDir returns correct path for win32', () => {
+	envRef.homeDir = ''
 	using _ = withPlatform('win32', {
 		LOCALAPPDATA: undefined,
 		APPDATA: undefined,
@@ -127,6 +141,7 @@ test('resolveCacheDir returns correct path for win32', () => {
 })
 
 test('resolveCacheDir returns correct path for linux', () => {
+	envRef.homeDir = ''
 	using _ = withPlatform('linux', {
 		XDG_CACHE_HOME: undefined,
 	})
@@ -136,6 +151,7 @@ test('resolveCacheDir returns correct path for linux', () => {
 })
 
 test('resolveCacheDir uses EPICSHOP_HOME_DIR override when provided', () => {
+	envRef.homeDir = '/custom/epicshop'
 	using _ = withPlatform('linux', {
 		EPICSHOP_HOME_DIR: '/custom/epicshop',
 	})


### PR DESCRIPTION
Allow `EPICSHOP_HOME_DIR` to override cache and primary data directories to ensure warmed caches are included in Docker images.

---
<a href="https://cursor.com/background-agent?bcId=bc-14d3dc74-e810-4fe6-aab3-2d4df118d26d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-14d3dc74-e810-4fe6-aab3-2d4df118d26d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds env-based override (EPICSHOP_HOME_DIR) for primary and cache directories and updates tests accordingly.
> 
> - **Workshop Utils**:
>   - **Config override**: Use `getEnv().EPICSHOP_HOME_DIR` to override `resolvePrimaryDir` and `resolveCacheDir` (via `getConfiguredHomeDir`).
>   - Import `getEnv` and route cache path to `path.join(EPICSHOP_HOME_DIR, 'cache')` when set.
> - **Tests**:
>   - Mock `./init-env.js` to supply `EPICSHOP_HOME_DIR` and add assertions for override behavior in `resolvePrimaryDir` and `resolveCacheDir`.
>   - Preserve and validate legacy migration paths across platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 024232e3eb5abd7f1d2a7e77860a9dcb05b912b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->