### PR TITLE
Video access for tabs

### DIFF
--- a/packages/workshop-app/app/components/diff.tsx
+++ b/packages/workshop-app/app/components/diff.tsx
@@ -55,11 +55,14 @@ function RevalidateApps({
 export function Diff({
 	diff,
 	allApps,
+	hasAccess,
 }: {
 	diff: Promise<diffProp> | diffProp
 	allApps: Array<{ name: string; displayName: string }>
+	hasAccess?: boolean
 }) {
 	const userHasAccess = useUserHasAccess()
+	const canAccess = hasAccess ?? userHasAccess
 	const submit = useSubmit()
 	const [params] = useSearchParams()
 	const paramsWithForcedRefresh = new URLSearchParams(params)
@@ -78,7 +81,7 @@ export function Diff({
 		)
 	}
 
-	if (!userHasAccess) {
+	if (!canAccess) {
 		return (
 			<div className="w-full p-12">
 				<div className="flex w-full flex-col gap-4 text-center">

--- a/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/__shared/tests.tsx
+++ b/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/__shared/tests.tsx
@@ -12,11 +12,13 @@ export function Tests({
 	problemAppName,
 	allApps,
 	isUpToDate,
+	hasAccess,
 }: {
 	appInfo: Pick<PlaygroundApp, 'appName' | 'name' | 'test'> | null
 	problemAppName?: string
 	allApps: Array<{ name: string; displayName: string }>
 	isUpToDate: boolean
+	hasAccess?: boolean
 }) {
 	return (
 		<PlaygroundWindow
@@ -25,20 +27,23 @@ export function Tests({
 			allApps={allApps}
 			isUpToDate={isUpToDate}
 		>
-			<TestUI playgroundAppInfo={playgroundAppInfo} />
+			<TestUI playgroundAppInfo={playgroundAppInfo} hasAccess={hasAccess} />
 		</PlaygroundWindow>
 	)
 }
 
 export function TestUI({
 	playgroundAppInfo,
+	hasAccess,
 }: {
 	playgroundAppInfo: Pick<PlaygroundApp, 'name' | 'test'> | null
+	hasAccess?: boolean
 }) {
 	const [inBrowserTestKey, setInBrowserTestKey] = useState(0)
 	const userHasAccess = useUserHasAccess()
+	const canAccess = hasAccess ?? userHasAccess
 
-	if (!userHasAccess) {
+	if (!canAccess) {
 		return (
 			<div className="w-full p-12">
 				<div className="flex w-full flex-col gap-4 text-center">

--- a/packages/workshop-app/app/routes/diff.tsx
+++ b/packages/workshop-app/app/routes/diff.tsx
@@ -5,6 +5,7 @@ import {
 	isExerciseStepApp,
 } from '@epic-web/workshop-utils/apps.server'
 import { getDiffCode } from '@epic-web/workshop-utils/diff.server'
+import { userHasAccessToWorkshopOrVideos } from '@epic-web/workshop-utils/epic-api.server'
 import { makeTimings } from '@epic-web/workshop-utils/timing.server'
 import {
 	type LoaderFunctionArgs,
@@ -37,6 +38,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
 	const app2 = app2Name
 		? await getAppByName(app2Name)
 		: allAppsFull.filter(isExerciseStepApp).at(-1)
+
+	const canAccessDiff = await userHasAccessToWorkshopOrVideos({
+		request,
+		timings,
+		epicVideoEmbeds: [app1?.epicVideoEmbeds?.[0], app2?.epicVideoEmbeds?.[0]],
+	})
 
 	async function getDiffProp() {
 		if (!app1 || !app2) {
@@ -96,6 +103,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 	return {
 		allApps,
 		diff,
+		canAccessDiff,
 		prevLink:
 			prevApp1 && prevApp2
 				? { to: `/diff?${prevSearchParams}`, 'aria-label': 'Previous App' }
@@ -125,7 +133,7 @@ export default function DiffViewer() {
 			})}
 		>
 			<div className="overflow-y-auto">
-				<Diff diff={data.diff} allApps={data.allApps} />
+				<Diff diff={data.diff} allApps={data.allApps} hasAccess={data.canAccessDiff} />
 			</div>
 			<div className="flex h-16 items-center justify-end border-t">
 				<NavChevrons prev={data.prevLink} next={data.nextLink} />


### PR DESCRIPTION
Open Diff and Test tabs for users with access to the associated video, in addition to existing workshop access.

Previously, Diff and Test tabs were strictly paywalled by workshop product access. This change introduces a new layer of access control, allowing users to access these features if they are entitled to the specific video associated with the exercise step (either from the step's MDX or the overall exercise instructions), or if they have general workshop product access. This ensures users who have purchased individual video content can utilize the interactive features relevant to that content.

---
<a href="https://cursor.com/background-agent?bcId=bc-5340ad83-01c7-464c-a127-095836c9d4d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5340ad83-01c7-464c-a127-095836c9d4d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

