### PR TITLE
Lesson video access control

### DIFF
--- a/packages/workshop-app/app/components/diff.tsx
+++ b/packages/workshop-app/app/components/diff.tsx
@@ -19,7 +19,7 @@ import { DeferredEpicVideo } from './epic-video.tsx'
 import { Icon } from './icons.tsx'
 import { useRevalidationWS } from './revalidation-ws.tsx'
 import { SimpleTooltip } from './ui/tooltip.tsx'
-import { useUserHasAccess } from './user.tsx'
+import { useUserHasAccessToLesson } from './user.tsx'
 
 type diffProp = {
 	app1?: string
@@ -59,7 +59,7 @@ export function Diff({
 	diff: Promise<diffProp> | diffProp
 	allApps: Array<{ name: string; displayName: string }>
 }) {
-	const userHasAccess = useUserHasAccess()
+	const userHasAccess = useUserHasAccessToLesson()
 	const submit = useSubmit()
 	const [params] = useSearchParams()
 	const paramsWithForcedRefresh = new URLSearchParams(params)
@@ -84,7 +84,7 @@ export function Diff({
 				<div className="flex w-full flex-col gap-4 text-center">
 					<p className="text-2xl font-bold">Access Denied</p>
 					<p className="text-lg">
-						You must login or register for the workshop to view the diff.
+						You must login and have access to this lesson to view the diff.
 					</p>
 				</div>
 				<div className="h-16" />

--- a/packages/workshop-app/app/components/user.tsx
+++ b/packages/workshop-app/app/components/user.tsx
@@ -1,3 +1,4 @@
+import { useParams } from 'react-router'
 import { useRootLoaderData } from '#app/utils/root-loader.ts'
 
 export function useOptionalUser() {
@@ -43,4 +44,24 @@ export function useDiscordMember() {
 export function useUserHasAccess() {
 	const data = useRootLoaderData()
 	return data.userHasAccess
+}
+
+export function useUserHasAccessToLesson(exerciseNumber?: number) {
+	const data = useRootLoaderData()
+	const params = useParams()
+
+	// Full workshop access implies lesson access.
+	if (data.userHasAccess) return true
+
+	const inferredExerciseNumber =
+		exerciseNumber ??
+		(params.exerciseNumber ? Number(params.exerciseNumber) : undefined)
+
+	if (!inferredExerciseNumber || !Number.isFinite(inferredExerciseNumber)) {
+		return false
+	}
+
+	return Boolean(
+		data.lessonFirstEpicVideoAccess?.[inferredExerciseNumber] ?? false,
+	)
 }

--- a/packages/workshop-app/app/root.tsx
+++ b/packages/workshop-app/app/root.tsx
@@ -56,6 +56,7 @@ import appStylesheetUrl from './styles/app.css?url'
 import tailwindStylesheetUrl from './styles/tailwind.css?url'
 import { ClientHintCheck, getHints } from './utils/client-hints'
 import { getConfetti } from './utils/confetti.server'
+import { getLessonFirstEpicVideoAccess } from './utils/lesson-access.server.ts'
 import { cn, combineHeaders, getDomainUrl, useAltDown } from './utils/misc'
 import { Presence } from './utils/presence'
 import { getSeoMetaTags } from './utils/seo'
@@ -123,6 +124,16 @@ export async function loader({ request }: Route.LoaderArgs) {
 		}),
 		user: getUserInfo(),
 		userHasAccess: userHasAccessToWorkshop({ request, timings }),
+		lessonFirstEpicVideoAccessInfo: getLessonFirstEpicVideoAccess({
+			request,
+			timings,
+		}).catch((e) => {
+			console.error('Failed to get lesson first epic video access', e)
+			return {
+				lessonFirstEpicVideoAccess: {} as Record<number, boolean>,
+				firstVideoUrlByExerciseNumber: {} as Record<number, string>,
+			} as const
+		}),
 		apps: getApps({ request, timings }),
 		repoUpdates: checkForUpdatesCached(),
 		unmutedNotifications: getUnmutedNotifications(),
@@ -178,6 +189,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 			},
 			repoUpdates,
 			exerciseChanges: asyncStuff.exerciseChanges,
+			lessonFirstEpicVideoAccess:
+				asyncStuff.lessonFirstEpicVideoAccessInfo.lessonFirstEpicVideoAccess,
 		},
 		{
 			headers: combineHeaders(

--- a/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/__shared/tests.tsx
+++ b/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/__shared/tests.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { DeferredEpicVideo } from '#app/components/epic-video.js'
 import { Icon } from '#app/components/icons'
 import { InBrowserTestRunner } from '#app/components/in-browser-test-runner'
-import { useUserHasAccess } from '#app/components/user.js'
+import { useUserHasAccessToLesson } from '#app/components/user.tsx'
 import { TestOutput } from '#app/routes/test'
 import { PlaygroundWindow } from './playground-window'
 
@@ -36,7 +36,7 @@ export function TestUI({
 	playgroundAppInfo: Pick<PlaygroundApp, 'name' | 'test'> | null
 }) {
 	const [inBrowserTestKey, setInBrowserTestKey] = useState(0)
-	const userHasAccess = useUserHasAccess()
+	const userHasAccess = useUserHasAccessToLesson()
 
 	if (!userHasAccess) {
 		return (
@@ -44,7 +44,7 @@ export function TestUI({
 				<div className="flex w-full flex-col gap-4 text-center">
 					<p className="text-2xl font-bold">Access Denied</p>
 					<p className="text-lg">
-						You must login or register for the workshop to view and run the
+						You must login and have access to this lesson to view and run the
 						tests.
 					</p>
 				</div>

--- a/packages/workshop-app/app/utils/lesson-access.server.ts
+++ b/packages/workshop-app/app/utils/lesson-access.server.ts
@@ -1,0 +1,84 @@
+import { getExercises } from '@epic-web/workshop-utils/apps.server'
+import { getEpicVideoInfos } from '@epic-web/workshop-utils/epic-api.server'
+import { type Timings } from '@epic-web/workshop-utils/timing.server'
+
+function getFirstEpicVideoUrlForExercise(exercise: {
+	exerciseNumber: number
+	instructionsEpicVideoEmbeds?: Array<string> | undefined
+	finishedEpicVideoEmbeds?: Array<string> | undefined
+	steps: Array<
+		| {
+				stepNumber: number
+				problem?: { epicVideoEmbeds?: Array<string> | undefined } | undefined
+				solution?: { epicVideoEmbeds?: Array<string> | undefined } | undefined
+		  }
+		| undefined
+	>
+}) {
+	const direct =
+		exercise.instructionsEpicVideoEmbeds?.[0] ??
+		exercise.steps
+			.filter(Boolean)
+			.sort((a, b) => a.stepNumber - b.stepNumber)
+			.flatMap((step) => [
+				step.problem?.epicVideoEmbeds?.[0],
+				step.solution?.epicVideoEmbeds?.[0],
+			])
+			.find(Boolean) ??
+		exercise.finishedEpicVideoEmbeds?.[0]
+
+	return direct ?? null
+}
+
+export async function getLessonFirstEpicVideoAccess({
+	request,
+	timings,
+}: {
+	request: Request
+	timings?: Timings
+}) {
+	const exercises = await getExercises({ request, timings })
+
+	const firstVideoUrlByExerciseNumber: Record<number, string> = {}
+	for (const exercise of exercises) {
+		const firstUrl = getFirstEpicVideoUrlForExercise(exercise)
+		if (firstUrl) firstVideoUrlByExerciseNumber[exercise.exerciseNumber] = firstUrl
+	}
+
+	const uniqueUrls = Array.from(
+		new Set(Object.values(firstVideoUrlByExerciseNumber)),
+	)
+	const videoInfos = await getEpicVideoInfos(uniqueUrls, { request, timings })
+
+	const lessonFirstEpicVideoAccess: Record<number, boolean> = {}
+	for (const [exerciseNumberString, url] of Object.entries(
+		firstVideoUrlByExerciseNumber,
+	)) {
+		const exerciseNumber = Number(exerciseNumberString)
+		const info = videoInfos[url]
+		lessonFirstEpicVideoAccess[exerciseNumber] = info?.status === 'success'
+	}
+
+	return { lessonFirstEpicVideoAccess, firstVideoUrlByExerciseNumber } as const
+}
+
+export async function getUserHasAccessToLessonFirstEpicVideo({
+	request,
+	timings,
+	exerciseNumber,
+}: {
+	request: Request
+	timings?: Timings
+	exerciseNumber: number
+}) {
+	const exercises = await getExercises({ request, timings })
+	const exercise = exercises.find((e) => e.exerciseNumber === exerciseNumber)
+	if (!exercise) return false
+
+	const url = getFirstEpicVideoUrlForExercise(exercise)
+	if (!url) return false
+
+	const videoInfos = await getEpicVideoInfos([url], { request, timings })
+	return videoInfos[url]?.status === 'success'
+}
+


### PR DESCRIPTION
Gate Test and Diff tabs by adding per-lesson video access data to the root loader, allowing users with individual lesson access to view them.

---
<a href="https://cursor.com/background-agent?bcId=bc-ceb67454-8fa7-4d4f-a48b-418e1e67c299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ceb67454-8fa7-4d4f-a48b-418e1e67c299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gates Diff and Tests tabs using per-lesson Epic video access, wiring lesson access data through the root loader and enforcing it in the exercise route and UI.
> 
> - **Access control**:
>   - Add per-lesson access checks via `useUserHasAccessToLesson` (replaces `useUserHasAccess`) in `components/user.tsx`, `components/diff.tsx`, and tests UI.
>   - Update access-denied copy to require login and lesson access.
> - **Server utilities**:
>   - Introduce `utils/lesson-access.server.ts` with `getLessonFirstEpicVideoAccess` and `getUserHasAccessToLessonFirstEpicVideo` to resolve first Epic video URL per exercise and determine access.
> - **Root loader** (`app/root.tsx`):
>   - Fetch and expose `lessonFirstEpicVideoAccess` in loader data.
> - **Exercise route** (`routes/.../index.tsx`):
>   - Compute `userHasAccessToLesson` in loader; gate diff generation and tab visibility (`tests`, `diff`).
>   - Pass diff denial as compiled MDX when access is missing.
> - **UI behavior**:
>   - Hide `tests` and `diff` tabs without lesson access; keep existing runtime/test status logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc7f181bb457506041560d250687815eea998864. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->