### PR TITLE
Issue resolution

### DIFF
--- a/packages/workshop-cli/src/commands/workshops.ts
+++ b/packages/workshop-cli/src/commands/workshops.ts
@@ -2130,13 +2130,22 @@ type CommandResult = {
 	error?: Error
 }
 
+function resolveCliCommand(command: string): string {
+	// On Windows, package manager binaries are typically shimmed as *.cmd files.
+	// Spawning "npm" directly can fail with ENOENT even though "npm.cmd" exists.
+	if (process.platform === 'win32' && (command === 'npm' || command === 'npx')) {
+		return `${command}.cmd`
+	}
+	return command
+}
+
 function runCommand(
 	command: string,
 	args: string[],
 	options: { cwd: string; silent?: boolean },
 ): Promise<CommandResult> {
 	return new Promise((resolve) => {
-		const child = spawn(command, args, {
+		const child = spawn(resolveCliCommand(command), args, {
 			cwd: options.cwd,
 			stdio: options.silent ? 'pipe' : 'inherit',
 		})
@@ -2164,7 +2173,7 @@ function runCommandInteractive(
 	options: { cwd: string },
 ): Promise<CommandResult> {
 	return new Promise((resolve) => {
-		const child = spawn(command, args, {
+		const child = spawn(resolveCliCommand(command), args, {
 			cwd: options.cwd,
 			stdio: 'inherit',
 		})


### PR DESCRIPTION
Fix `spawn npm ENOENT` errors on Windows by resolving `npm` and `npx` to their `.cmd` counterparts.

The CLI was spawning `npm` directly via Node’s `spawn()`, which can fail on Windows because the executable is typically `npm.cmd`. This change explicitly resolves `npm`/`npx` to `*.cmd` on Windows before spawning.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed93897b-4fc3-4981-8db3-3fc4d40ca0f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed93897b-4fc3-4981-8db3-3fc4d40ca0f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `resolveCliCommand` to map `npm`/`npx` to `.cmd` on Windows and updates command spawns to use it.
> 
> - **CLI (workshop-cli)**:
>   - Add `resolveCliCommand` in `packages/workshop-cli/src/commands/workshops.ts` to map `npm`/`npx` to `.cmd` on Windows.
>   - Update `runCommand` and `runCommandInteractive` to spawn `resolveCliCommand(command)` to prevent `ENOENT` when invoking package manager commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f20b7876596013844d4a4472de13dad985618a73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->