### PR TITLE
Workshop repo update script

### DIFF
--- a/other/update-workshops/package-lock.json
+++ b/other/update-workshops/package-lock.json
@@ -7,29 +7,7 @@
 			"name": "update-workshops",
 			"dependencies": {
 				"execa": "^9.5.2",
-				"globby": "^14.1.0",
-				"minimatch": "^10.1.1"
-			}
-		},
-		"node_modules/@isaacs/balanced-match": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-			"license": "MIT",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@isaacs/brace-expansion": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-			"license": "MIT",
-			"dependencies": {
-				"@isaacs/balanced-match": "^4.0.1"
-			},
-			"engines": {
-				"node": "20 || >=22"
+				"globby": "^14.1.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -359,21 +337,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/minimatch": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-			"integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/brace-expansion": "^5.0.0"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/npm-run-path": {

--- a/other/update-workshops/package.json
+++ b/other/update-workshops/package.json
@@ -7,7 +7,6 @@
 	},
 	"dependencies": {
 		"execa": "^9.5.2",
-		"globby": "^14.1.0",
-		"minimatch": "^10.1.1"
+		"globby": "^14.1.0"
 	}
 }


### PR DESCRIPTION
Refactor the workshop update script to correctly identify `npm install` targets in monorepos, preventing unnecessary installs in sub-workspaces.

Previously, the script only considered `workspaces` configurations from `package.json` files that had changed. If a workspace root's `package.json` was not updated, its workspace rules were ignored, leading to `npm install` being run in sub-workspaces or nested `package.json` directories unnecessarily. This change ensures all `package.json` files are scanned for workspace configurations, and `npm install` is run only at the appropriate workspace root (or the package's own directory if not part of a workspace). It also removes an unused `minimatch` dependency.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a002ddb-8bb7-4e0d-bf32-7dcf19d50a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1a002ddb-8bb7-4e0d-bf32-7dcf19d50a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Determines minimal npm install targets by detecting workspace roots across all package.json files and removes the unused minimatch dependency.
> 
> - **Script updates (`other/update-workshops/index.js`)**:
>   - Implement `getInstallDirsForChangedPackages` to scan all `package.json` files, expand workspace members, and run installs at workspace roots instead of sub-packages.
>   - Add helpers: `workspacePatternToPackageJsonGlob` and `isSameOrInsideDir`; sort workspace roots by depth to choose the correct root.
>   - Replace per-changed-package installs with per-root installs; improved logging of install locations.
> - **Dependencies**:
>   - Remove `minimatch` from `package.json` and lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e66eac46edf49e0c28ca4428080718292560a30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->