### PR TITLE
Workshop repo update script

### DIFF
--- a/other/update-workshops/package-lock.json
+++ b/other/update-workshops/package-lock.json
@@ -7,29 +7,7 @@
 			"name": "update-workshops",
 			"dependencies": {
 				"execa": "^9.5.2",
-				"globby": "^14.1.0",
-				"minimatch": "^10.1.1"
-			}
-		},
-		"node_modules/@isaacs/balanced-match": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-			"license": "MIT",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@isaacs/brace-expansion": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-			"license": "MIT",
-			"dependencies": {
-				"@isaacs/balanced-match": "^4.0.1"
-			},
-			"engines": {
-				"node": "20 || >=22"
+				"globby": "^14.1.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -359,21 +337,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/minimatch": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-			"integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/brace-expansion": "^5.0.0"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/npm-run-path": {

--- a/other/update-workshops/package.json
+++ b/other/update-workshops/package.json
@@ -7,7 +7,6 @@
 	},
 	"dependencies": {
 		"execa": "^9.5.2",
-		"globby": "^14.1.0",
-		"minimatch": "^10.1.1"
+		"globby": "^14.1.0"
 	}
 }


### PR DESCRIPTION
Simplify the workshop repo update script to only run `npm install` in the repo root and `./epicshop`, removing complex workspace detection logic and the `minimatch` dependency.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fc9edee-a1ce-4822-96b7-218c3f651b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3fc9edee-a1ce-4822-96b7-218c3f651b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the workshop updater to run installs only in the repo root and `./epicshop`, removing workspace detection logic and the `minimatch` dependency.
> 
> - **Script (`other/update-workshops/index.js`)**:
>   - Simplifies update flow: run `npm install --ignore-scripts` only in repo root and in `./epicshop` when present (no per-package installs).
>   - Removes workspace detection/filtering logic and related helpers.
>   - Updates `updatePackageJsonFiles` to return `{ changed, pkgs }` (no `changedPkgs`) and adjusts call sites.
>   - Adds safe check for `./epicshop/package.json` before installing.
> - **Dependencies**:
>   - Removes `minimatch` from `package.json` and cleans related entries from `package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7806bc1b49431b915443879f18a7794e3ddaa93b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->