### PR TITLE
Add command directory argument

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -109,13 +109,13 @@ epicshop init
 epicshop init
 ```
 
-### `add <repo-name>`
+### `add <repo-name> [destination]`
 
 Add a workshop by cloning it from the epicweb-dev GitHub organization and
 running the setup script.
 
 ```bash
-epicshop add <repo-name> [options]
+epicshop add <repo-name> [destination] [options]
 ```
 
 #### Options
@@ -130,6 +130,9 @@ epicshop add <repo-name> [options]
 # Clone and set up the full-stack-foundations workshop
 epicshop add full-stack-foundations
 
+# Clone to a specific destination directory (bypasses configured repos directory)
+epicshop add react-fundamentals ~/Desktop/react-fundamentals
+
 # Clone to a custom directory
 epicshop add web-forms --directory ~/my-workshops
 ```
@@ -138,7 +141,7 @@ epicshop add web-forms --directory ~/my-workshops
 
 1. Clones the repository from `https://github.com/epicweb-dev/<repo-name>`
 2. Runs `npm run setup` in the cloned directory
-3. Adds the workshop to your local workshop registry
+3. If cloned into your configured repos directory, it will show up in `epicshop list` and can be started/opened by name
 
 #### Interactive Workshop Selection
 

--- a/packages/workshop-cli/README.md
+++ b/packages/workshop-cli/README.md
@@ -41,7 +41,7 @@ epicshop start <workshop>
 
 ### Helpful commands
 
-- `epicshop add <repo-name>`: clone a workshop from the `epicweb-dev` GitHub org
+- `epicshop add <repo-name> [destination]`: clone a workshop from the `epicweb-dev` GitHub org
 - `epicshop list`: list your workshops
 - `epicshop open`: open a workshop in your editor
 - `epicshop update`: pull the latest workshop changes

--- a/packages/workshop-cli/src/cli.ts
+++ b/packages/workshop-cli/src/cli.ts
@@ -169,13 +169,18 @@ const cli = yargs(args)
 		},
 	)
 	.command(
-		'add [repo-name]',
+		'add [repo-name] [destination]',
 		'Add a workshop by cloning from epicweb-dev GitHub org',
 		(yargs: Argv) => {
 			return yargs
 				.positional('repo-name', {
 					describe:
 						'Repository name from epicweb-dev org (optional, shows list if omitted)',
+					type: 'string',
+				})
+				.positional('destination', {
+					describe:
+						'Optional directory to clone into (full path). If provided, this bypasses the configured repos directory.',
 					type: 'string',
 				})
 				.option('directory', {
@@ -199,10 +204,15 @@ const cli = yargs(args)
 					'$0 add web-forms --directory ~/my-workshops',
 					'Clone workshop to a custom directory',
 				)
+				.example(
+					'$0 add react-fundamentals ~/Desktop/react-fundamentals',
+					'Clone workshop to a specific destination directory',
+				)
 		},
 		async (
 			argv: ArgumentsCamelCase<{
 				repoName?: string
+				destination?: string
 				directory?: string
 				silent?: boolean
 			}>,
@@ -210,6 +220,7 @@ const cli = yargs(args)
 			const { add } = await import('./commands/workshops.js')
 			const result = await add({
 				repoName: argv.repoName,
+				destination: argv.destination,
 				directory: argv.directory,
 				silent: argv.silent,
 			})


### PR DESCRIPTION
Add an optional `destination` positional argument to `epicshop add` to allow users to specify a custom clone directory, bypassing the default managed location.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fe070f0-e6b9-47ea-90b7-ebebf96cb0bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6fe070f0-e6b9-47ea-90b7-ebebf96cb0bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional `destination` positional to `epicshop add` to clone into a specific path (with `~` expansion), bypassing the managed repos dir and adjusting setup/existence checks.
> 
> - **CLI**
>   - Add positional `destination` to `epicshop add` in `src/cli.ts` with examples.
> - **Command Logic (`src/commands/workshops.ts`)**
>   - Extend `AddOptions` with `destination`; add `resolvePathWithTilde`.
>   - Support cloning to either an existing parent directory or a full target path.
>   - Bypass `ensureConfigured()` and `workshopExists` checks when an explicit `destination`/`--directory` is provided.
>   - Normalize paths (tilde expansion, `path.resolve`); ensure parent dir exists; update success message.
> - **Docs**
>   - Update `docs/cli.md` and `packages/workshop-cli/README.md` to document `add <repo-name> [destination]`, usage examples, and note visibility in `epicshop list` only when cloned into the managed repos directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c40b2eb8ad8c6b39056367eab4833f9298834fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->