### PR TITLE
Workshop already added logging

### DIFF
--- a/packages/workshop-cli/src/commands/workshops.ts
+++ b/packages/workshop-cli/src/commands/workshops.ts
@@ -518,7 +518,18 @@ export async function add(options: AddOptions): Promise<WorkshopsResult> {
 		if (!hasExplicitCloneDestination) {
 			if (await workshopExists(repoName)) {
 				const message = `Workshop "${repoName}" already exists`
-				if (!silent) console.log(chalk.yellow(`⚠️  ${message}`))
+				if (!silent) {
+					const reposDir = await getReposDirectory()
+					const workshopPath = path.join(reposDir, repoName)
+					const openCommand = `npx epicshop open ${repoName}`
+					const startCommand = `npx epicshop start ${repoName}`
+
+					console.log(chalk.yellow(`⚠️  ${message}`))
+					console.log(chalk.gray(`   Location on disk: ${workshopPath}`))
+					console.log(chalk.gray(`   You can run:`))
+					console.log(chalk.white.bold(`   ${openCommand}`))
+					console.log(chalk.white.bold(`   ${startCommand}`))
+				}
 				return { success: false, message }
 			}
 		}


### PR DESCRIPTION
Enhance the `epicshop add` command's "workshop already exists" warning to include the on-disk path and suggested `open` and `start` commands.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a1c291f-4b4c-42e2-af44-d891e1d1ca43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a1c291f-4b4c-42e2-af44-d891e1d1ca43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the duplicate-workshop UX in `epicshop add`.
> 
> - When a workshop already exists (managed repos dir, non-silent), logs the workshop’s disk location via `getReposDirectory()` and shows suggested commands: `npx epicshop open <repo>` and `npx epicshop start <repo>`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 530cfe800e0317599ba039f6cf98c567d94d0be8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->