### PR TITLE
User location activity status

### DIFF
--- a/packages/workshop-presence/src/presence.ts
+++ b/packages/workshop-presence/src/presence.ts
@@ -33,6 +33,8 @@ export const LocationSchema = z.object({
 	epicshopVersion: z.string().nullable().optional(),
 	// Repository status (updates available, commits ahead/behind) for this location/workshop
 	repoStatus: RepoStatusSchema.nullable().optional(),
+	// ISO timestamp of when the user last sent an update for this location (server-set)
+	lastUpdatedAt: z.string().nullable().optional(),
 })
 
 export type Location = z.infer<typeof LocationSchema>


### PR DESCRIPTION
Add user activity tracking to the presence show page to display active and inactive users.

Users are now considered inactive if their location hasn't been updated in over 30 minutes, providing insight into active workshop participation.

---
<a href="https://cursor.com/background-agent?bcId=bc-c59a4184-4249-4787-ba1c-5b7a2b5def52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c59a4184-4249-4787-ba1c-5b7a2b5def52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces lightweight activity tracking and UI indicators for user presence.
> 
> - Extend `Location` and connection state with `lastUpdatedAt`; set on `add-user`/`add-anonymous-user` and propagate/merge across multiple connections
> - Add inactivity threshold (30m), `isLocationActive`, and `getActivityStats` to compute Active/Inactive counts for users
> - Update `/show` rendering to display Active/Inactive stats, per-user "Inactive" badge, and "Last active" timestamp; include corresponding styles
> - Preserve backward compatibility by assuming active when timestamps are missing and by continuing to expose `location` alongside `locations`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5900bd7c99a87a3a74c413c45478ccaf2a6c7680. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->