### PR TITLE
Multi-select workshops

### DIFF
--- a/packages/workshop-cli/src/commands/workshops.ts
+++ b/packages/workshop-cli/src/commands/workshops.ts
@@ -400,9 +400,10 @@ async function addSingleWorkshop(
 	let workshopPath: string
 
 	if (options.destination?.trim()) {
-		// destination can be either:
-		// - a parent directory (existing) => clone into <destination>/<repoName>
-		// - a full target path (non-existing) => clone into <destination>
+		// destination is always treated as a parent directory
+		// - if it exists and is a directory: clone into <destination>/<repoName>
+		// - if it doesn't exist: create it and clone into <destination>/<repoName>
+		// This ensures consistent behavior for both single and multiple workshop setups
 		const resolvedDestination = path.resolve(
 			resolvePathWithTilde(options.destination),
 		)
@@ -419,9 +420,9 @@ async function addSingleWorkshop(
 				}
 			}
 		} catch {
-			// Destination doesn't exist. Treat it as the exact clone target path.
-			workshopPath = resolvedDestination
-			reposDir = path.dirname(workshopPath)
+			// Destination doesn't exist. Create it as a parent directory and clone inside.
+			reposDir = resolvedDestination
+			workshopPath = path.join(reposDir, repoName)
 		}
 	} else {
 		reposDir = options.directory?.trim()
@@ -921,9 +922,11 @@ export async function add(options: AddOptions): Promise<WorkshopsResult> {
 		}
 
 		// Use the helper to set up the single workshop (when repo was provided via CLI args)
-		console.log(chalk.cyan(`🏎️  Setting up ${chalk.bold(repoName)}...\n`))
+		if (!silent) {
+			console.log(chalk.cyan(`🏎️  Setting up ${chalk.bold(repoName)}...\n`))
+		}
 		const result = await addSingleWorkshop(repoName, options)
-		if (result.success) {
+		if (result.success && !silent) {
 			console.log(chalk.green(`🏁 Finished setting up ${chalk.bold(repoName)}\n`))
 			console.log(chalk.white('Run:'))
 			console.log(


### PR DESCRIPTION
Refactor workshop setup to use a multi-select checkbox prompt, making multi-workshop selection more intuitive.

The previous implementation used a single-select `search` prompt within a loop, which was confusing for users expecting to select multiple items simultaneously. This change directly addresses issue #427 by providing clear inline instructions and a standard multi-select interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-604e9c60-1db9-4951-bbf5-28d0ec6e2c1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-604e9c60-1db9-4951-bbf5-28d0ec6e2c1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a checkbox-based, multi-select workflow for adding workshops and onboarding, with quick-select options and batched setup with progress and summaries.
> 
> - **New selection UX** in `add` and onboarding: quick-select “All My Workshops”, per-product groups, or individual selection via `checkbox`; optional “Browse all”/“Skip” paths; searchable fallback when needed
> - **Bulk setup flow**: confirm before batching, per-item progress, cleanup on failures, final success/failure summary, and avoids re-adding existing workshops
> - **Refactor**: extract `addSingleWorkshop` to handle clone/setup/cleanup and reuse across flows; improves messages and post-setup guidance (`npx epicshop open/start`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7629448b348d806c6917a6e4651426bd02ff427d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->