### PR TITLE
onboarding hint

### DIFF
--- a/packages/workshop-app/app/components/onboarding-hint.tsx
+++ b/packages/workshop-app/app/components/onboarding-hint.tsx
@@ -1,0 +1,41 @@
+import { useFetcher } from 'react-router'
+import { Icon } from './icons.tsx'
+
+export function OnboardingHint({
+	className,
+}: {
+	className?: string
+}) {
+	const fetcher = useFetcher()
+	const isSubmitting = fetcher.state !== 'idle'
+
+	// Don't show if currently being dismissed
+	if (isSubmitting) {
+		return null
+	}
+
+	return (
+		<div
+			className={`border-border bg-accent/50 relative flex items-center justify-between gap-3 border-b px-4 py-2 text-sm ${className ?? ''}`}
+		>
+			<div className="flex items-center gap-2">
+				<Icon name="Notify" className="text-primary h-4 w-4 shrink-0" />
+				<span className="text-muted-foreground">
+					<span className="font-medium text-foreground">New here?</span> If
+					you're unfamiliar with how this app works, check out the intro
+					instructions on the home page for a quick overview.
+				</span>
+			</div>
+			<fetcher.Form method="post" action="/dismiss-onboarding-hint">
+				<button
+					type="submit"
+					className="text-muted-foreground hover:text-foreground flex shrink-0 items-center gap-1 text-xs transition-colors"
+					aria-label="Dismiss hint"
+				>
+					<Icon name="Close" className="h-3 w-3" />
+					<span className="sr-only sm:not-sr-only">Dismiss</span>
+				</button>
+			</fetcher.Form>
+		</div>
+	)
+}

--- a/packages/workshop-app/app/routes/_app+/index.tsx
+++ b/packages/workshop-app/app/routes/_app+/index.tsx
@@ -15,9 +15,11 @@ import slugify from '@sindresorhus/slugify'
 import { data, type HeadersFunction, Link } from 'react-router'
 import { EpicVideoInfoProvider } from '#app/components/epic-video.tsx'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
+import { OnboardingHint } from '#app/components/onboarding-hint.tsx'
 import { EditFileOnGitHub } from '#app/routes/launch-editor.tsx'
 import { Mdx } from '#app/utils/mdx.tsx'
 import { cn } from '#app/utils/misc.tsx'
+import { useRootLoaderData } from '#app/utils/root-loader.ts'
 import { ProgressToggle, useExerciseProgressClassName } from '../progress.tsx'
 import { type Route } from './+types/index.tsx'
 
@@ -104,6 +106,10 @@ function ExerciseListItem({
 const mdxComponents = { h1: () => null }
 
 export default function Index({ loaderData: data }: Route.ComponentProps) {
+	const rootData = useRootLoaderData()
+	const showOnboardingHint =
+		!rootData.preferences?.onboardingHint?.dismissed && !ENV.EPICSHOP_DEPLOYED
+
 	const exerciseLinks = (
 		<ul className="divide-border dark:divide-border/50 flex flex-col divide-y">
 			<strong className="px-10 pb-3 font-mono text-xs uppercase">
@@ -120,6 +126,7 @@ export default function Index({ loaderData: data }: Route.ComponentProps) {
 	)
 	return (
 		<main className="relative flex h-full w-full max-w-5xl flex-col justify-between border-r md:w-3/4 xl:w-2/3">
+			{showOnboardingHint ? <OnboardingHint /> : null}
 			<article
 				id={data.articleId}
 				className="shadow-on-scrollbox scrollbar-thin scrollbar-thumb-scrollbar flex w-full flex-1 flex-col gap-12 overflow-y-scroll px-3 py-4 pt-6 md:px-10 md:py-12 md:pt-16"

--- a/packages/workshop-app/app/routes/_app+/preferences.tsx
+++ b/packages/workshop-app/app/routes/_app+/preferences.tsx
@@ -26,6 +26,7 @@ export async function action({ request }: { request: Request }) {
 	const optOutPresence = formData.get('optOutPresence') === 'on'
 	const persistPlayground = formData.get('persistPlayground') === 'on'
 	const dismissExerciseWarning = formData.get('dismissExerciseWarning') === 'on'
+	const dismissOnboardingHint = formData.get('dismissOnboardingHint') === 'on'
 
 	await setPreferences({
 		player: {
@@ -36,6 +37,7 @@ export async function action({ request }: { request: Request }) {
 		presence: { optOut: optOutPresence },
 		playground: { persist: persistPlayground },
 		exerciseWarning: { dismissed: dismissExerciseWarning },
+		onboardingHint: { dismissed: dismissOnboardingHint },
 	})
 
 	return redirectWithToast('/preferences', {
@@ -52,6 +54,7 @@ export default function AccountSettings() {
 	const presencePreferences = rootData.preferences?.presence
 	const playgroundPreferences = rootData.preferences?.playground
 	const exerciseWarningPreferences = rootData.preferences?.exerciseWarning
+	const onboardingHintPreferences = rootData.preferences?.onboardingHint
 	const navigation = useNavigation()
 
 	const isSubmitting = navigation.state === 'submitting'
@@ -180,6 +183,29 @@ export default function AccountSettings() {
 							/>
 							<label htmlFor="dismissExerciseWarning">
 								Dismiss exercise directory warnings
+							</label>
+						</div>
+					</div>
+
+					<div>
+						<div className="mb-2 flex items-center gap-2">
+							<h2 className="text-body-xl">Onboarding Hint</h2>
+
+							<SimpleTooltip
+								content={`The onboarding hint appears at the top of the home page to help new users find the intro instructions.`}
+							>
+								<Icon name="Question" tabIndex={0} />
+							</SimpleTooltip>
+						</div>
+						<div className="flex items-center gap-2">
+							<input
+								type="checkbox"
+								id="dismissOnboardingHint"
+								name="dismissOnboardingHint"
+								defaultChecked={onboardingHintPreferences?.dismissed}
+							/>
+							<label htmlFor="dismissOnboardingHint">
+								Dismiss onboarding hint
 							</label>
 						</div>
 					</div>

--- a/packages/workshop-app/app/routes/dismiss-onboarding-hint.tsx
+++ b/packages/workshop-app/app/routes/dismiss-onboarding-hint.tsx
@@ -1,0 +1,13 @@
+import { setPreferences } from '@epic-web/workshop-utils/db.server'
+import { data, type ActionFunctionArgs } from 'react-router'
+import { ensureUndeployed } from '#app/utils/misc.tsx'
+
+export async function action({ request: _request }: ActionFunctionArgs) {
+	ensureUndeployed()
+
+	await setPreferences({
+		onboardingHint: { dismissed: true },
+	})
+
+	return data({ success: true })
+}

--- a/packages/workshop-utils/src/db.server.ts
+++ b/packages/workshop-utils/src/db.server.ts
@@ -75,6 +75,12 @@ const DataSchema = z.object({
 				})
 				.optional()
 				.default({ dismissed: false }),
+			onboardingHint: z
+				.object({
+					dismissed: z.boolean().default(false),
+				})
+				.optional()
+				.default({ dismissed: false }),
 		})
 		.optional()
 		.default({}),
@@ -321,6 +327,10 @@ export async function setPreferences(
 			exerciseWarning: {
 				...data?.preferences?.exerciseWarning,
 				...preferences?.exerciseWarning,
+			},
+			onboardingHint: {
+				...data?.preferences?.onboardingHint,
+				...preferences?.onboardingHint,
 			},
 		},
 	}


### PR DESCRIPTION
Add a dismissible onboarding hint to the home page to provide low-friction guidance for users who skip instructions (fixes #429).

---
<a href="https://cursor.com/background-agent?bcId=bc-b262d083-df56-466c-99f6-1f5bdcb7a402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b262d083-df56-466c-99f6-1f5bdcb7a402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

