### PR TITLE
Workshop product slug check

### DIFF
--- a/packages/workshop-cli/src/commands/workshops.ts
+++ b/packages/workshop-cli/src/commands/workshops.ts
@@ -2281,8 +2281,8 @@ async function promptAndSetupAccessibleWorkshops(): Promise<void> {
 	console.log(chalk.gray(`  🔑 You have access to this workshop`))
 	console.log()
 
-	// Filter workshops that have a product configured (for "All My Workshops" option)
-	const workshopsWithProduct = candidates.filter((w) => w.productHost)
+	// Filter workshops that are part of a product (for "All My Workshops" option)
+	const workshopsWithProduct = candidates.filter((w) => w.productSlug)
 
 	// Group workshops by product for quick-select options
 	const workshopsByProduct = new Map<string, string[]>()


### PR DESCRIPTION
Correct CLI workshop filtering to use `productSlug` for product association instead of `productHost`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4519303-f73c-47b2-b1a5-8296d95b0d21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4519303-f73c-47b2-b1a5-8296d95b0d21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates workshop selection logic during onboarding/setup:
> 
> - Filters `workshopsWithProduct` by `productSlug` (instead of `productHost`) to correctly identify product-linked workshops for the "All My Workshops" and per-product quick-select options.
> 
> No other behavior changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 896048fe036ff65bfb94f3431c8eb8d37f9c6e74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->