### PR TITLE
Exercise step header visibility

### DIFF
--- a/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
@@ -403,7 +403,7 @@ export default function ExercisePartRoute({
 								className="hover:underline"
 							>
 								<span>{titleBits.exerciseNumber}.</span>
-								<span className="hidden @min-[400px]:inline">
+								<span className="hidden @min-[500px]:inline">
 									{' '}
 									{titleBits.exerciseTitle}
 								</span>
@@ -411,12 +411,12 @@ export default function ExercisePartRoute({
 							<span>/</span>
 							<Link to="." className="hover:underline">
 								<span>{titleBits.stepNumber}.</span>
-								<span className="hidden @min-[600px]:inline">
+								<span className="hidden @min-[300px]:inline">
 									{' '}
 									{titleBits.title}
 								</span>
 								<span> ({titleBits.emoji}</span>
-								<span className="hidden @min-[500px]:inline">
+								<span className="hidden @min-[400px]:inline">
 									{' '}
 									{titleBits.type}
 								</span>
@@ -429,6 +429,7 @@ export default function ExercisePartRoute({
 							<SetAppToPlayground
 								appName={data.problem.name}
 								isOutdated={data.playground?.isUpToDate === false}
+								hideTextOnNarrow
 							/>
 						) : null}
 					</div>

--- a/packages/workshop-app/app/routes/set-playground.tsx
+++ b/packages/workshop-app/app/routes/set-playground.tsx
@@ -228,9 +228,12 @@ function SelectItem({
 export function SetAppToPlayground({
 	appName,
 	isOutdated,
+	hideTextOnNarrow,
 }: {
 	appName: string
 	isOutdated?: boolean
+	/** When true, hides text at narrow container widths (for use in @container contexts) */
+	hideTextOnNarrow?: boolean
 }) {
 	if (ENV.EPICSHOP_DEPLOYED) return null
 	return (
@@ -244,7 +247,13 @@ export function SetAppToPlayground({
 		>
 			<span className="text-foreground-destructive flex items-center justify-center gap-1 hover:underline">
 				<Icon name="Unlinked" className="animate-ping" />{' '}
-				<span className="hidden @min-[300px]:inline uppercase">
+				<span
+					className={
+						hideTextOnNarrow
+							? 'hidden @min-[600px]:inline uppercase'
+							: 'uppercase'
+					}
+				>
 					{isOutdated ? 'Playground Outdated' : 'Set to Playground'}
 				</span>
 			</span>


### PR DESCRIPTION
Add container queries to the exercise step header to progressively hide text elements, preventing horizontal scrolling on narrow screens.

Elements are hidden in a specific priority order: step title, problem/solution text, exercise title, and 'Set to playground' text, ensuring critical information remains visible longer.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c2524bd-eaa4-49e9-896e-49b2e4478fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c2524bd-eaa4-49e9-896e-49b2e4478fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves header responsiveness to prevent horizontal scrolling on narrow containers.
> 
> - Refactors exercise step header in `_layout.tsx` to use `@container` and conditional spans to progressively hide `exerciseTitle`, `title`, and `type` at small widths
> - Always renders `SetAppToPlayground` in the header and passes `hideTextOnNarrow` to collapse its label on narrow containers
> - Adds `hideTextOnNarrow` prop to `SetAppToPlayground` in `set-playground.tsx` to control label visibility via container queries
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3659e254b3ba535342fe9aa60259f4ded1dbcb14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->