### PR TITLE
Workshop clone path

### DIFF
--- a/packages/workshop-cli/src/commands/workshops.test.ts
+++ b/packages/workshop-cli/src/commands/workshops.test.ts
@@ -48,6 +48,33 @@ describe('workshops add', () => {
 			await fs.rm(baseDir, { recursive: true, force: true })
 		}
 	})
+
+	it('uses destination as the clone path', async () => {
+		vi.mocked(execa).mockResolvedValue({} as never)
+
+		const baseDir = await fs.mkdtemp(
+			path.join(os.tmpdir(), 'epicshop destination '),
+		)
+		const destination = path.join(baseDir, 'workshop-target')
+
+		try {
+			const repoName = 'data-modeling'
+			const result = await add({ repoName, destination, silent: true })
+
+			expect(result.success).toBe(true)
+
+			const repoUrl = `https://github.com/epicweb-dev/${repoName}.git`
+			const expectedCwd = path.dirname(destination)
+
+			expect(execa).toHaveBeenCalledWith(
+				'git',
+				['clone', repoUrl, destination],
+				expect.objectContaining({ cwd: expectedCwd }),
+			)
+		} finally {
+			await fs.rm(baseDir, { recursive: true, force: true })
+		}
+	})
 })
 
 describe('workshops start', () => {

--- a/packages/workshop-cli/src/commands/workshops.ts
+++ b/packages/workshop-cli/src/commands/workshops.ts
@@ -400,30 +400,12 @@ async function addSingleWorkshop(
 	let workshopPath: string
 
 	if (options.destination?.trim()) {
-		// destination is always treated as a parent directory
-		// - if it exists and is a directory: clone into <destination>/<repoName>
-		// - if it doesn't exist: create it and clone into <destination>/<repoName>
-		// This ensures consistent behavior for both single and multiple workshop setups
+		// destination is treated as the final clone path
 		const resolvedDestination = path.resolve(
 			resolvePathWithTilde(options.destination),
 		)
-
-		try {
-			const stat = await fs.promises.stat(resolvedDestination)
-			if (stat.isDirectory()) {
-				reposDir = resolvedDestination
-				workshopPath = path.join(reposDir, repoName)
-			} else {
-				return {
-					success: false,
-					message: `Destination is not a directory: ${resolvedDestination}`,
-				}
-			}
-		} catch {
-			// Destination doesn't exist. Create it as a parent directory and clone inside.
-			reposDir = resolvedDestination
-			workshopPath = path.join(reposDir, repoName)
-		}
+		workshopPath = resolvedDestination
+		reposDir = path.dirname(resolvedDestination)
 	} else {
 		reposDir = options.directory?.trim()
 			? path.resolve(resolvePathWithTilde(options.directory))


### PR DESCRIPTION
Fixes the `epicshop add` command to clone workshops directly into the specified destination path.

Previously, `epicshop add <repo> <destination>` would clone the repository into `<destination>/<repo>`, even when the user intended `<destination>` to be the final location. This change ensures that the provided `destination` is treated as the exact target path for the cloned repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3ae64f3-62ba-4889-bb9d-ad14b4bcfb03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3ae64f3-62ba-4889-bb9d-ad14b4bcfb03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix clone path behavior for `epicshop add`**
> 
> - Treats `destination` as the exact clone target (`workshopPath = resolvedDestination`; `reposDir = dirname(destination)`), rather than a parent directory
> - Ensures `reposDir` is created and used as `cwd` for `git clone`
> - Adds test validating cloning into the specified `destination` path
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d7bacb9c7f379eecb51bb82c90e3c6ba7856b79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->