### PR TITLE
Video download error handling

### DIFF
--- a/docs/debug-logging.md
+++ b/docs/debug-logging.md
@@ -69,6 +69,21 @@ This will show logs for all `epic:api` operations including:
 - Error conditions with stack traces
 - Performance timing information
 
+### Offline Video Downloads
+
+Use the `epic:offline-videos` namespace to diagnose offline video downloads:
+
+```bash
+NODE_DEBUG=epic:offline-videos npm run dev
+```
+
+This will show logs for:
+
+- Offline video download requests
+- Mux URL attempts and failures
+- Successful download sizes
+- Error details when downloads fail
+
 ### Cache Debugging
 
 The workshop app includes integrated cache logging that shows detailed cache

--- a/docs/video-player.md
+++ b/docs/video-player.md
@@ -47,7 +47,7 @@ files to embed Epic Web videos with enhanced features.
 - **Theme Support**: Automatically adapts to light/dark themes
 - **Offline Handling**: Graceful fallback when offline
 - **Offline Downloads (Local)**: Optional bulk downloads from Preferences for
-  offline playback, encrypted at rest
+  offline playback, encrypted at rest, with toast errors on failures
 - **Region Restrictions**: Handles region-restricted content with upgrade
   prompts
 
@@ -122,6 +122,8 @@ The video player gracefully handles various error scenarios:
 - **Region Restrictions**: Shows upgrade prompts for restricted content
 - **Authentication Errors**: Provides login/upgrade links
 - **Network Issues**: Shows offline indicators
+- **Offline Download Failures**: Shows toast errors and logs via
+  `NODE_DEBUG=epic:offline-videos`
 - **Invalid URLs**: Displays error messages
 - **Missing Transcripts**: Falls back to basic video embed
 

--- a/packages/workshop-app/app/components/epic-video.tsx
+++ b/packages/workshop-app/app/components/epic-video.tsx
@@ -58,6 +58,7 @@ function getOfflineVideoResolutionLabel(value: unknown) {
 type OfflineVideoActionData = {
 	status: string
 	action?: string
+	message?: string
 }
 
 function useOfflineVideoAvailability(playbackId: string, refreshKey: number) {
@@ -687,6 +688,15 @@ function EpicVideo({
 		if (offlineVideoFetcher.data?.status) {
 			setAvailabilityKey((key) => key + 1)
 		}
+	}, [offlineVideoFetcher.state, offlineVideoFetcher.data])
+
+	React.useEffect(() => {
+		if (offlineVideoFetcher.state !== 'idle') return
+		const data = offlineVideoFetcher.data
+		if (!data || data.action !== 'download' || data.status !== 'error') return
+		const description =
+			data.message ?? 'Offline video download failed. Check the terminal logs.'
+		toast.error('Offline video download failed', { description })
 	}, [offlineVideoFetcher.state, offlineVideoFetcher.data])
 
 	const handleDownload = React.useCallback(() => {

--- a/packages/workshop-app/app/routes/resources+/offline-videos.ts
+++ b/packages/workshop-app/app/routes/resources+/offline-videos.ts
@@ -39,7 +39,13 @@ export async function action({ request }: ActionFunctionArgs) {
 			)
 		}
 		const result = await downloadOfflineVideo({ playbackId, title, url })
-		return data({ status: result.status, action: 'download' } as const)
+		return data({
+			status: result.status,
+			action: 'download',
+			...(result.status === 'error' && 'message' in result
+				? { message: result.message }
+				: {}),
+		} as const)
 	}
 
 	if (intent === 'delete-video') {


### PR DESCRIPTION
Add UI error toasts and detailed logging for failed offline video downloads to provide user feedback and aid debugging.

Previously, users received no notification when an offline video download failed, and there was no diagnostic information available in the logs, making it difficult to understand and resolve issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecda31eb-cf64-4d65-a57b-1078bda5e22a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ecda31eb-cf64-4d65-a57b-1078bda5e22a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances offline video download diagnostics and user feedback.
> 
> - **UI**: `epic-video.tsx` shows toast errors when `download` fails (reads `message` from action data) and refreshes availability after actions
> - **Server**: `offline-videos.server.ts` adds `epic:offline-videos` logs (request, Mux attempts, non-OK responses, completion, queueing, missing key info, failures); returns clearer error messages for missing key and catch-all failures; logs sizes on success
> - **API**: `resources+/offline-videos.ts` includes `message` in `download` error responses
> - **Docs**: Add `epic:offline-videos` debug namespace and note toast errors in video player error handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea2e70f1fbf9ecf4e362ad0cbb22d8e1c47428e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->