### PR TITLE
Exercise step page scrolling

### DIFF
--- a/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
@@ -392,10 +392,10 @@ export default function ExercisePartRoute({
 		<div className="flex max-w-full grow flex-col">
 			<main
 				ref={containerRef}
-				className="flex grow flex-col sm:h-full sm:min-h-[800px] md:min-h-[unset] lg:flex-row"
+				className="flex grow flex-col overflow-y-auto sm:h-full sm:min-h-[800px] md:min-h-[unset] lg:flex-row lg:overflow-y-hidden"
 			>
 				<div
-					className="relative flex min-w-0 flex-none basis-full flex-col sm:col-span-1 sm:row-span-1 sm:h-full lg:basis-(--split-pct)"
+					className="relative flex min-w-0 flex-none basis-auto flex-col sm:col-span-1 sm:row-span-1 lg:h-full lg:basis-(--split-pct)"
 					style={{ ['--split-pct' as any]: `${splitPercent}%` }}
 					ref={leftPaneRef}
 				>
@@ -442,7 +442,7 @@ export default function ExercisePartRoute({
 					<article
 						id={data.articleId}
 						key={data.articleId}
-						className="shadow-on-scrollbox scrollbar-thin scrollbar-thumb-scrollbar flex h-full w-full max-w-none flex-1 scroll-pt-6 flex-col justify-between space-y-6 overflow-y-auto p-2 sm:p-10 sm:pt-8"
+						className="shadow-on-scrollbox scrollbar-thin scrollbar-thumb-scrollbar flex w-full max-w-none scroll-pt-6 flex-col justify-between space-y-6 p-2 sm:p-10 sm:pt-8 lg:h-full lg:flex-1 lg:overflow-y-auto"
 					>
 						{data.exerciseStepApp.instructionsCode ? (
 							<StepMdx inBrowserBrowserRef={inBrowserBrowserRef} />
@@ -537,7 +537,7 @@ export default function ExercisePartRoute({
 						if (firstTouch) startDrag(firstTouch.clientX)
 					}}
 				/>
-				<div className="flex min-w-0 flex-1">
+				<div className="flex min-w-0 flex-none min-h-[50vh] lg:min-h-0 lg:flex-1">
 					<Outlet context={{ inBrowserBrowserRef }} />
 				</div>
 			</main>


### PR DESCRIPTION
Adjusts the layout of the exercise step page to improve scrolling on narrow screens.

Ensures the preview tabs are reachable by allowing the content to scroll vertically when the screen is narrow, while maintaining the split-pane layout on wider screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-80ef8d00-5317-46e9-a4ca-1c9635371a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80ef8d00-5317-46e9-a4ca-1c9635371a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves narrow-screen usability by enabling vertical scrolling and refining split-pane behavior at larger breakpoints.
> 
> - `main`: adds `overflow-y-auto` by default and `lg:overflow-y-hidden` to constrain scrolling on large screens
> - Left pane container: switches to `basis-auto`, applies `lg:h-full` and `lg:basis-(--split-pct)` for proper split sizing
> - `article`: moves height/scroll to large screens (`lg:h-full lg:flex-1 lg:overflow-y-auto`) to allow content to scroll on small screens
> - Right pane: changes to `flex-none` with `min-h-[50vh]` on small screens and `lg:flex-1` to maintain split on large
> - Overall: ensures preview tabs/content remain reachable on small screens without breaking desktop layout
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36d2e55bcf1f99c07350f46345f20319e541b827. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->