### PR TITLE
Enotdir error handling

### DIFF
--- a/packages/workshop-utils/src/apps.server.ts
+++ b/packages/workshop-utils/src/apps.server.ts
@@ -25,6 +25,7 @@ import {
 import { compileMdx } from './compile-mdx.server.ts'
 import { getAppConfig, getStackBlitzUrl } from './config.server.ts'
 import { getPreferences } from './db.server.ts'
+import { logger } from './logger.ts'
 import { getDirModifiedTime } from './modified-time.server.ts'
 import {
 	closeProcess,
@@ -36,7 +37,6 @@ import { requestStorageify } from './request-context.server.ts'
 import { getServerTimeHeader, time, type Timings } from './timing.server.ts'
 import { dayjs } from './utils.server.ts'
 import { getErrorMessage } from './utils.ts'
-import { logger } from './logger.ts'
 
 const log = logger('epic:apps')
 


### PR DESCRIPTION
Gracefully handle `ENOTDIR` errors by filtering non-directory entries in `getExampleApps` and adding specific error handling in `getTestInfo`.

The `getExampleApps` function was incorrectly treating files (like `README.mdx`) within the `examples` directory as directories, leading to `ENOTDIR` errors when subsequent functions (e.g., `getTestInfo`) attempted to call `readdir` on these file paths. This PR ensures only actual directories are processed and logs skipped non-directory entries.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f5fa76c-ea08-418f-86a2-775062b2423f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f5fa76c-ea08-418f-86a2-775062b2423f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents `ENOTDIR` errors when scanning examples and tests; adds targeted logging.
> 
> - **`getExampleApps`**: use `fs.readdir(..., { withFileTypes: true })`, include only directory entries, log skipped non-directories, and tolerate missing `examples` dir
> - **`getTestInfo`**: wrap `readdir` in try/catch; on `ENOTDIR` log and skip, otherwise rethrow; returns `none` when no tests found
> - Add `logger` and `log` helper in `apps.server.ts` for diagnostics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52b7db9d368ddb118936fac0d609ee2006052ddc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->