### PR TITLE
Mdx component definition

### DIFF
--- a/packages/workshop-app/app/routes/_app+/examples+/$example.tsx
+++ b/packages/workshop-app/app/routes/_app+/examples+/$example.tsx
@@ -16,7 +16,7 @@ import {
 } from '@epic-web/workshop-utils/timing.server'
 import slugify from '@sindresorhus/slugify'
 import * as cookie from 'cookie'
-import { useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import {
 	Link,
 	data,
@@ -33,7 +33,7 @@ import { useRevalidationWS } from '#app/components/revalidation-ws.tsx'
 import { Preview } from '#app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/__shared/preview.tsx'
 import { getAppRunningState } from '#app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/__shared/utils.tsx'
 import { EditFileOnGitHub } from '#app/routes/launch-editor.tsx'
-import { Mdx } from '#app/utils/mdx.tsx'
+import { createInlineFileComponent, Mdx } from '#app/utils/mdx.tsx'
 import { getRootMatchLoaderData } from '#app/utils/root-loader.ts'
 import { getSeoMetaTags } from '#app/utils/seo.ts'
 
@@ -154,15 +154,25 @@ export const headers: HeadersFunction = ({ loaderHeaders, parentHeaders }) => {
 	return headers
 }
 
-// we'll render the title ourselves thank you
-const mdxComponents = { h1: () => null }
-
 export default function ExampleRoute() {
 	const data = useLoaderData<typeof loader>()
 	const inBrowserBrowserRef = useRef<InBrowserBrowserRef>(null)
 	const containerRef = useRef<HTMLDivElement>(null)
 	const leftPaneRef = useRef<HTMLDivElement>(null)
 	const [splitPercent, setSplitPercent] = useState<number>(data.splitPercent)
+
+	// Create MDX components with example-specific InlineFile
+	const mdxComponents = useMemo(() => {
+		const InlineFile = createInlineFileComponent(() => ({
+			name: data.example.name,
+			fullPath: data.example.fullPath,
+		}))
+		return {
+			// we'll render the title ourselves thank you
+			h1: () => null,
+			InlineFile,
+		}
+	}, [data.example.name, data.example.fullPath])
 
 	useRevalidationWS({
 		watchPaths: [data.exampleReadme.file],

--- a/packages/workshop-app/app/utils/mdx.tsx
+++ b/packages/workshop-app/app/utils/mdx.tsx
@@ -2,12 +2,14 @@ import { clsx } from 'clsx'
 import { LRUCache } from 'lru-cache'
 import { type MDXContentProps } from 'mdx-bundler/client'
 import * as mdxBundler from 'mdx-bundler/client'
-import { useEffect, useMemo, useState } from 'react'
+import { type PropsWithChildren, useEffect, useMemo, useState } from 'react'
 import { Link, useLoaderData } from 'react-router'
 import { toast } from 'sonner'
+import iconsSvg from '#app/assets/icons.svg'
 import { DeferredEpicVideo, VideoEmbed } from '#app/components/epic-video.tsx'
 import { Icon } from '#app/components/icons.tsx'
 import { Mermaid } from '#app/components/mermaid.tsx'
+import { SimpleTooltip } from '#app/components/ui/tooltip.tsx'
 import { type loader } from '#app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx'
 import { LaunchEditor } from '#app/routes/launch-editor.tsx'
 import { AnchorOrLink, Heading, cn } from './misc.tsx'
@@ -264,4 +266,54 @@ export function Mdx({
 		[externalComponents],
 	)
 	return <Component components={components} />
+}
+
+/**
+ * App info used by MDX components like InlineFile
+ */
+export type MdxAppInfo = {
+	name: string
+	fullPath: string
+}
+
+/**
+ * Creates an InlineFile component that opens files in the editor
+ * @param getApp - Function to get the app info given the type
+ * @returns InlineFile component
+ */
+export function createInlineFileComponent(getApp: () => MdxAppInfo | null) {
+	return function InlineFile({
+		file,
+		children = <code>{file}</code>,
+		...props
+	}: Omit<PropsWithChildren<typeof LaunchEditor>, 'appName'> & {
+		file: string
+	}) {
+		const app = getApp()
+
+		const info = (
+			<div className="launch-editor-button-wrapper flex underline underline-offset-4">
+				{children}{' '}
+				<svg height={24} width={24}>
+					<use href={`${iconsSvg}#Keyboard`} />
+				</svg>
+			</div>
+		)
+
+		if (!app) {
+			return (
+				<SimpleTooltip content="App information not available">
+					<div className="inline-block grow cursor-not-allowed">{info}</div>
+				</SimpleTooltip>
+			)
+		}
+
+		return (
+			<div className="inline-block grow">
+				<LaunchEditor appFile={file} appName={app.name} {...props}>
+					{info}
+				</LaunchEditor>
+			</div>
+		)
+	}
 }


### PR DESCRIPTION
Provide `InlineFile` MDX component to example pages to resolve 'component not defined' errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ac3a086-b1ca-4943-aed7-5aa8f6b3b415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ac3a086-b1ca-4943-aed7-5aa8f6b3b415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an `InlineFile` MDX component and wires it into example pages so MDX can link directly to open files in the editor.
> 
> - Adds `createInlineFileComponent` in `utils/mdx.tsx` to generate an `InlineFile` component using `LaunchEditor`, with tooltip fallback and icon UI
> - Updates `routes/_app+/examples+/$example.tsx` to build MDX components via `useMemo`, injecting example-specific `InlineFile` (and still suppressing `h1`)
> - Minor import adjustments to support the new component
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 335de032e1b6a191630b1be7c0257d402067451e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->