### PR TITLE
Tailwind not-prose styling

### DIFF
--- a/packages/workshop-app/app/styles/tailwind.css
+++ b/packages/workshop-app/app/styles/tailwind.css
@@ -235,7 +235,7 @@
 /* Typography plugin customizations */
 @layer components {
 	/* proseColors */
-	.prose :where(*) {
+	.prose :where(*):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
 		color: hsl(var(--foreground));
 	}
 
@@ -254,10 +254,12 @@
 	}
 
 	/* removeCodeBackticks */
-	.prose :where(code)::before {
+	.prose
+		:where(code):not(:where([class~='not-prose'], [class~='not-prose'] *))::before {
 		content: none;
 	}
-	.prose :where(code)::after {
+	.prose
+		:where(code):not(:where([class~='not-prose'], [class~='not-prose'] *))::after {
 		content: none;
 	}
 }


### PR DESCRIPTION
Fix `not-prose` class in Tailwind Typography by updating custom `.prose` overrides to correctly exclude `not-prose` content.

Custom `.prose` overrides in `tailwind.css` were using a selector that did not account for `not-prose`, causing styles to be re-applied even within `not-prose` blocks. This PR modifies these selectors to include the same `not(:where([class~='not-prose'], [class~='not-prose'] *))` exclusion as the official Tailwind Typography plugin.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd13e4c3-2a6f-43e0-a486-e12bac8afb92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd13e4c3-2a6f-43e0-a486-e12bac8afb92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures custom Typography styles do not affect `not-prose` content.
> 
> - Updates `.prose :where(*)` to `.prose :where(*):not(:where([class~='not-prose'], [class~='not-prose'] *))` for color inheritance
> - Applies the same `not-prose` exclusion to `.prose :where(code)::before` and `::after` to remove backtick content only within prose
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2724b3c69aaca92bde8b45cbff4434d26caeaf2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->