### PR TITLE
Modal escape key propagation

### DIFF
--- a/packages/workshop-app/app/routes/_app+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/_layout.tsx
@@ -1553,13 +1553,23 @@ function NavToggle({
 	React.useEffect(() => {
 		if (!isMenuOpened) return
 
-		function handleKeyUp(event: KeyboardEvent) {
-			if (event.key === 'Escape') {
+		function handleKeyDown(event: KeyboardEvent) {
+			if (event.key !== 'Escape' || event.defaultPrevented) {
+				return
+			}
+
+			const hasOpenDialog = Boolean(
+				document.querySelector(
+					'[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]',
+				),
+			)
+
+			if (!hasOpenDialog) {
 				menuButtonRef.current?.click()
 			}
 		}
-		document.addEventListener('keyup', handleKeyUp)
-		return () => document.removeEventListener('keyup', handleKeyUp)
+		document.addEventListener('keydown', handleKeyDown)
+		return () => document.removeEventListener('keydown', handleKeyDown)
 	}, [isMenuOpened])
 
 	return (


### PR DESCRIPTION
Guard the navigation menu's Escape key handler to prevent it from closing when a modal dialog is open.

---
<a href="https://cursor.com/background-agent?bcId=bc-c325000d-f95e-424a-a068-ce7d68c316d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c325000d-f95e-424a-a068-ce7d68c316d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Escape key handling for the mobile/side navigation.
> 
> - Replaces `keyup` with `keydown` listener for `Escape` in `NavToggle` within `_layout.tsx`
> - Ignores events with `event.defaultPrevented`
> - Prevents menu from closing if a `[role="dialog"|"alertdialog"][data-state="open"]` exists
> - Keeps behavior of toggling the menu via `menuButtonRef.current?.click()` when appropriate
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 410dec587f24586637b41601992096f35eb5bb1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->