### PR TITLE
Playground chooser contrast

### DIFF
--- a/packages/workshop-app/app/routes/set-playground.tsx
+++ b/packages/workshop-app/app/routes/set-playground.tsx
@@ -562,7 +562,7 @@ export function PlaygroundChooser({
 				<Select.Trigger
 					aria-label="Select app for playground"
 					className={clsx(
-						'radix-placeholder:text-muted-foreground flex h-full w-full items-center justify-between text-left focus-visible:outline-none',
+						'radix-placeholder:text-muted-foreground flex h-full w-full items-center justify-between rounded-md border border-border bg-muted/40 px-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:bg-muted/60',
 						fetcher.state !== 'idle' ? 'cursor-progress' : null,
 						fetcher.data?.status === 'error' ? 'cursor-not-allowed' : null,
 					)}


### PR DESCRIPTION
Add contrasting background, border, and focus/hover styles to the playground chooser trigger to improve its visibility against the page background.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ddc4f34-0907-4612-89fe-1251780be7d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ddc4f34-0907-4612-89fe-1251780be7d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves visibility and accessibility of the playground selector.
> 
> - Updates `Select.Trigger` in `set-playground.tsx` with `rounded-md` border, muted background, padding, hover state, and focus ring (`focus-visible:ring*`) to increase contrast and clarify focus/disabled states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49fc983e597cb7358542afb57bdf25b44b334aa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->