### PR TITLE
Downgrade zod to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26277,7 +26277,7 @@
         "tailwind-merge": "^3.4.0",
         "vite-env-only": "^3.0.3",
         "ws": "^8.19.0",
-        "zod": "^4.3.5"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
@@ -26934,15 +26934,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/workshop-app/node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "packages/workshop-cli": {
       "name": "epicshop",
       "version": "0.0.0-semantically-released",
@@ -27196,7 +27187,7 @@
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@sentry/node": "^10.35.0",
         "openid-client": "^6.8.1",
-        "zod": "^4.3.5"
+        "zod": "^3.25.76"
       },
       "bin": {
         "workshop-mcp": "dist/index.js"
@@ -27210,36 +27201,18 @@
         "zshy": "^0.7.0"
       }
     },
-    "packages/workshop-mcp/node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "packages/workshop-presence": {
       "name": "@epic-web/workshop-presence",
       "version": "0.0.0-semantically-released",
       "dependencies": {
         "@epic-web/workshop-utils": "file:../workshop-utils",
-        "zod": "^4.3.5"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "partykit": "0.0.115",
         "typescript": "^5.9.3",
         "vitest": "^4.0.17",
         "zshy": "^0.7.0"
-      }
-    },
-    "packages/workshop-presence/node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "packages/workshop-utils": {
@@ -27296,7 +27269,7 @@
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.0.0",
-        "zod": "^4.3.5"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/hast": "^3.0.4",
@@ -27813,15 +27786,6 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/workshop-utils/node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/packages/workshop-app/package.json
+++ b/packages/workshop-app/package.json
@@ -109,7 +109,7 @@
     "tailwind-merge": "^3.4.0",
     "vite-env-only": "^3.0.3",
     "ws": "^8.19.0",
-    "zod": "^4.3.5"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",

--- a/packages/workshop-mcp/package.json
+++ b/packages/workshop-mcp/package.json
@@ -44,15 +44,15 @@
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@sentry/node": "^10.35.0",
     "openid-client": "^6.8.1",
-    "zod": "^4.3.5"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.18.0",
     "@types/node": "^25.0.9",
-    "zshy": "^0.7.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.17"
+    "vitest": "^4.0.17",
+    "zshy": "^0.7.0"
   },
   "repository": {
     "type": "git",

--- a/packages/workshop-presence/package.json
+++ b/packages/workshop-presence/package.json
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@epic-web/workshop-utils": "file:../workshop-utils",
-    "zod": "^4.3.5"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "partykit": "0.0.115",
     "typescript": "^5.9.3",
-    "zshy": "^0.7.0",
-    "vitest": "^4.0.17"
+    "vitest": "^4.0.17",
+    "zshy": "^0.7.0"
   },
   "files": [
     "dist"

--- a/packages/workshop-utils/package.json
+++ b/packages/workshop-utils/package.json
@@ -234,7 +234,7 @@
     "unified": "^11.0.5",
     "unist-util-remove-position": "^5.0.0",
     "unist-util-visit": "^5.0.0",
-    "zod": "^4.3.5"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/hast": "^3.0.4",
@@ -243,8 +243,8 @@
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",
     "@types/shell-quote": "^1.7.5",
-    "zshy": "^0.7.0",
-    "vitest": "^4.0.17"
+    "vitest": "^4.0.17",
+    "zshy": "^0.7.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Dependency change**
> 
> - Downgrades `zod` from `^4.3.5` to `^3.25.76` in `workshop-app`, `workshop-mcp`, `workshop-presence`, and `workshop-utils`
> - Updates `package-lock.json` to remove v4 subdeps and reflect v3 resolution
> - Minor `devDependencies` ordering tweaks in some `package.json` files (no functional code changes)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea83f45f3d5ee524b6b206d50a1b50a5bfed67ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->