### PR TITLE
Extra apps navigation flow

### DIFF
--- a/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.finished.tsx
+++ b/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.finished.tsx
@@ -6,6 +6,7 @@ import {
 	getApps,
 	getExercise,
 	getWorkshopRoot,
+	isExtraApp,
 	isExerciseStepApp,
 } from '@epic-web/workshop-utils/apps.server'
 import { getWorkshopConfig } from '@epic-web/workshop-utils/config.server'
@@ -77,6 +78,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 	)
 
 	const apps = await getApps({ request, timings })
+	const hasExtras = apps.some(isExtraApp)
 	const exerciseApps = apps
 		.filter(isExerciseStepApp)
 		.filter((app) => app.exerciseNumber === exercise.exerciseNumber)
@@ -111,10 +113,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 						to: `/exercise/${nextExercise.exerciseNumber.toString().padStart(2, '0')}`,
 						'aria-label': `${nextExercise.title}`,
 					}
-				: {
-						to: '/finished',
-						'aria-label': 'Finished! 🎉',
-					},
+				: hasExtras
+					? {
+							to: '/extra',
+							'aria-label': 'Extras',
+						}
+					: {
+							to: '/finished',
+							'aria-label': 'Finished! 🎉',
+						},
 		},
 		{
 			headers: {

--- a/packages/workshop-app/app/routes/_app+/extra+/$extra.tsx
+++ b/packages/workshop-app/app/routes/_app+/extra+/$extra.tsx
@@ -237,6 +237,24 @@ export default function ExtraRoute() {
 		showPlaygroundIndicator || data.playground?.isUpToDate === false
 	const tabs = ['playground', 'extra', 'diff', 'chat'] as const
 	const preview = searchParams.get('preview')
+	const previousExtraLink = data.previousExtra
+		? {
+				to: `/extra/${data.previousExtra.dirName}`,
+				'aria-label': 'Previous Extra',
+			}
+		: {
+				to: '/extra',
+				'aria-label': 'Extras',
+			}
+	const nextExtraLink = data.nextExtra
+		? {
+				to: `/extra/${data.nextExtra.dirName}`,
+				'aria-label': 'Next Extra',
+			}
+		: {
+				to: '/finished',
+				'aria-label': 'Workshop finished',
+			}
 
 	function isValidPreview(
 		value: string | null,
@@ -350,30 +368,22 @@ export default function ExtraRoute() {
 							</div>
 						)}
 						<div className="mt-auto flex justify-between">
-							{data.previousExtra ? (
-								<Link
-									to={`/extra/${data.previousExtra.dirName}`}
-									aria-label="Previous Extra"
-									prefetch="intent"
-								>
-									<span aria-hidden>←</span>
-									<span className="hidden xl:inline"> Previous</span>
-								</Link>
-							) : (
-								<span />
-							)}
-							{data.nextExtra ? (
-								<Link
-									to={`/extra/${data.nextExtra.dirName}`}
-									aria-label="Next Extra"
-									prefetch="intent"
-								>
-									<span className="hidden xl:inline">Next </span>
-									<span aria-hidden>→</span>
-								</Link>
-							) : (
-								<span />
-							)}
+							<Link
+								to={previousExtraLink.to}
+								aria-label={previousExtraLink['aria-label']}
+								prefetch="intent"
+							>
+								<span aria-hidden>←</span>
+								<span className="hidden xl:inline"> Previous</span>
+							</Link>
+							<Link
+								to={nextExtraLink.to}
+								aria-label={nextExtraLink['aria-label']}
+								prefetch="intent"
+							>
+								<span className="hidden xl:inline">Next </span>
+								<span aria-hidden>→</span>
+							</Link>
 						</div>
 					</article>
 					<ElementScrollRestoration
@@ -386,24 +396,7 @@ export default function ExtraRoute() {
 							appName={data.extra.name}
 							relativePath={data.extraReadme.relativePath}
 						/>
-						<NavChevrons
-							prev={
-								data.previousExtra
-									? {
-											to: `/extra/${data.previousExtra.dirName}`,
-											'aria-label': 'Previous Extra',
-										}
-									: null
-							}
-							next={
-								data.nextExtra
-									? {
-											to: `/extra/${data.nextExtra.dirName}`,
-											'aria-label': 'Next Extra',
-										}
-									: null
-							}
-						/>
+						<NavChevrons prev={previousExtraLink} next={nextExtraLink} />
 					</div>
 				</div>
 				<div


### PR DESCRIPTION
Adjust navigation flow to guide users to extra apps after the last exercise and provide consistent navigation within the extra app section.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9ce580f-9298-4f94-99db-64c3511297c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9ce580f-9298-4f94-99db-64c3511297c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Exercise finished flow:** Import `isExtraApp` and compute `hasExtras`; `nextStepLink` now routes to `/extra` when extras exist, otherwise `/finished`.
> - **Extras page navigation:** Centralize `previousExtraLink`/`nextExtraLink` objects with fallbacks (`/extra` list and `/finished`), and reuse them for both inline links and `NavChevrons` to ensure consistent navigation across the Extras section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6eee313f502877310db1eccf799f0ffb8a34e63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->