### PR TITLE
Theme switcher popover logic

### DIFF
--- a/packages/workshop-app/app/routes/_app+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/_layout.tsx
@@ -802,6 +802,13 @@ function MobileNavigation({
 	const [isMobilePopoverOpen, setIsMobilePopoverOpen] = React.useState(false)
 	const showMobilePopover = Boolean(data.sidecarStatus)
 
+	// Reset popover state when it should not be shown to prevent stale state
+	React.useEffect(() => {
+		if (!showMobilePopover) {
+			setIsMobilePopoverOpen(false)
+		}
+	}, [showMobilePopover])
+
 	return (
 		<nav className="flex w-full border-b sm:hidden">
 			<div className="w-full">


### PR DESCRIPTION
Display the theme switcher directly in the mobile navigation when no sidecar status is present to avoid an unnecessary popover.

---
<a href="https://cursor.com/background-agent?bcId=bc-562d8fbc-dd63-4d0d-b88e-bba9b5b8d17d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-562d8fbc-dd63-4d0d-b88e-bba9b5b8d17d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves mobile navigation behavior around the theme switcher and sidecar indicator.
> 
> - Only shows the mobile popover when `data.sidecarStatus` is present; otherwise renders `ThemeSwitch` directly
> - Introduces `showMobilePopover` flag and an effect to reset `isMobilePopoverOpen` when the popover should not be shown to prevent stale state
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 435c949a8648f6330b5761dfd7deb7caccd777fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->