### PR TITLE
Offline video button state

### DIFF
--- a/packages/workshop-app/app/components/epic-video.tsx
+++ b/packages/workshop-app/app/components/epic-video.tsx
@@ -61,15 +61,28 @@ type OfflineVideoActionData = {
 	message?: string
 }
 
-function useOfflineVideoAvailability(playbackId: string, refreshKey: number) {
-	const [available, setAvailable] = React.useState(false)
-	const [checked, setChecked] = React.useState(false)
+type OfflineVideoAvailabilityOptions = {
+	initialAvailability?: boolean | null
+}
+
+function useOfflineVideoAvailability(
+	playbackId: string,
+	refreshKey: number,
+	options: OfflineVideoAvailabilityOptions = {},
+) {
+	const initialAvailability =
+		options.initialAvailability === undefined ? null : options.initialAvailability
+	const [available, setAvailable] = React.useState(initialAvailability ?? false)
+	const [checked, setChecked] = React.useState(initialAvailability !== null)
 	const offlineUrl = `/resources/offline-videos/${encodeURIComponent(playbackId)}`
 
 	React.useEffect(() => {
+		setAvailable(initialAvailability ?? false)
+		setChecked(initialAvailability !== null)
+	}, [initialAvailability, playbackId])
+
+	React.useEffect(() => {
 		if (typeof window === 'undefined') return
-		setAvailable(false)
-		setChecked(false)
 		const controller = new AbortController()
 		let isActive = true
 
@@ -485,10 +498,16 @@ function EpicVideo({
 	const downloadResolutionLabel = getOfflineVideoResolutionLabel(
 		rootData.preferences?.offlineVideo?.downloadResolution,
 	)
+	const offlineVideoPlaybackIds = rootData.offlineVideoPlaybackIds
+	const initialOfflineAvailability =
+		offlineVideoPlaybackIds == null
+			? null
+			: offlineVideoPlaybackIds.includes(muxPlaybackId)
 	const [availabilityKey, setAvailabilityKey] = React.useState(0)
 	const offlineVideo = useOfflineVideoAvailability(
 		muxPlaybackId,
 		availabilityKey,
+		{ initialAvailability: initialOfflineAvailability },
 	)
 	const shouldUseOfflineVideo = offlineVideo.available
 	const offlineVideoFetcher = useFetcher<OfflineVideoActionData>()
@@ -746,6 +765,7 @@ function EpicVideo({
 			isAvailable={offlineVideo.available}
 			isBusy={isOfflineActionBusy}
 			downloadProgress={downloadProgress}
+			isVisible={offlineVideo.checked}
 			onDownload={handleDownload}
 			onDelete={handleDelete}
 		/>

--- a/packages/workshop-app/app/components/offline-video-actions.tsx
+++ b/packages/workshop-app/app/components/offline-video-actions.tsx
@@ -44,6 +44,7 @@ function DeleteIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
 export type OfflineVideoActionButtonsProps = {
 	isAvailable: boolean
 	isBusy?: boolean
+	isVisible?: boolean
 	/**
 	 * Download progress percentage (0-100). When defined, shows a progress indicator.
 	 * When undefined and isBusy is true, shows an indeterminate progress indicator.
@@ -56,10 +57,19 @@ export type OfflineVideoActionButtonsProps = {
 export function OfflineVideoActionButtons({
 	isAvailable,
 	isBusy = false,
+	isVisible = true,
 	downloadProgress,
 	onDownload,
 	onDelete,
 }: OfflineVideoActionButtonsProps) {
+	if (!isVisible) {
+		return (
+			<span
+				aria-hidden="true"
+				className="inline-flex h-7 w-7 items-center justify-center rounded"
+			/>
+		)
+	}
 	const isDownloading = isBusy && !isAvailable
 	const showProgressIndicator = isDownloading
 	const label = isAvailable

--- a/packages/workshop-app/app/root.tsx
+++ b/packages/workshop-app/app/root.tsx
@@ -17,6 +17,7 @@ import {
 	checkForUpdatesCached,
 	checkForExerciseChanges,
 } from '@epic-web/workshop-utils/git.server'
+import { getOfflineVideoPlaybackIds } from '@epic-web/workshop-utils/offline-videos.server'
 import { getUnmutedNotifications } from '@epic-web/workshop-utils/notifications.server'
 import { makeTimings } from '@epic-web/workshop-utils/timing.server'
 import {
@@ -119,6 +120,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 		unmutedNotifications: getUnmutedNotifications(),
 		exerciseChanges: checkForExerciseChanges(),
 		loggedInProductHosts: getLoggedInProductHosts(),
+		offlineVideoPlaybackIds: getOfflineVideoPlaybackIds(),
 	})
 
 	const presentUsers = await getPresentUsers({
@@ -170,6 +172,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 			},
 			repoUpdates,
 			exerciseChanges: asyncStuff.exerciseChanges,
+			offlineVideoPlaybackIds: asyncStuff.offlineVideoPlaybackIds,
 		},
 		{
 			headers: combineHeaders(


### PR DESCRIPTION
Add server-side detection of offline video availability to prevent a flash of incorrect UI state on page load.

The original problem was a "flash of incorrect state" where the UI briefly showed a download button before switching to a delete button for already downloaded videos. This PR addresses this by making the server aware of which videos are offline, allowing the correct button to be rendered immediately, thus avoiding the client-side flicker. The action button is also hidden until its state is definitively known, further preventing visual shifts.

---
<a href="https://cursor.com/background-agent?bcId=bc-13997622-be6e-4422-85f2-ae54dcdf5b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-13997622-be6e-4422-85f2-ae54dcdf5b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces server-provided offline availability to eliminate initial UI flicker and defers action button rendering until state is known.
> 
> - Adds `getOfflineVideoPlaybackIds` in `offline-videos.server.ts` and exposes `offlineVideoPlaybackIds` from `root` loader
> - Updates `epic-video.tsx` to seed `useOfflineVideoAvailability` with `initialAvailability` from `rootData.offlineVideoPlaybackIds` and keep a `checked` flag
> - Enhances `OfflineVideoActionButtons` with `isVisible` prop (renders placeholder when unknown) and passes `isVisible={offlineVideo.checked}` from `EpicVideo`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75e1dd49daa467af4d413295dc262b03adfcf9ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->