### PR TITLE
Sourcemap sentry upload debugging

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1108,6 +1108,11 @@ setupWorkshop()
 - `NODE_ENV` - Set to `production` for production mode
 - `SENTRY_DSN` - Sentry DSN for error tracking and distributed tracing in
   production
+- `SENTRY_AUTH_TOKEN` - Sentry auth token for source map uploads during build
+- `SENTRY_ORG` - Sentry organization slug for source map uploads
+- `SENTRY_PROJECT` - Sentry project slug for source map uploads
+- `SENTRY_RELEASE` - Optional release name for matching source maps to events
+- `EPICSHOP_APP_COMMIT_SHA` - Release fallback for source map matching
 
 ## Interactive Features
 

--- a/packages/workshop-app/app/utils/monitoring.client.ts
+++ b/packages/workshop-app/app/utils/monitoring.client.ts
@@ -88,10 +88,16 @@ export function init() {
 
 	if (tracingIntegration) integrations.unshift(tracingIntegration)
 
+	const release =
+		ENV.SENTRY_RELEASE ??
+		ENV.EPICSHOP_APP_COMMIT_SHA ??
+		ENV.EPICSHOP_APP_VERSION
+
 	Sentry.init({
 		dsn: ENV.SENTRY_DSN,
 		sendDefaultPii: true,
 		environment: ENV.MODE,
+		release,
 		tunnel: '/resources/lookout',
 		tracePropagationTargets,
 		ignoreErrors: [

--- a/packages/workshop-app/instrument.js
+++ b/packages/workshop-app/instrument.js
@@ -23,12 +23,17 @@ const profilingModule = await import('@sentry/profiling-node').catch(
 )
 
 const nodeProfilingIntegration = profilingModule?.nodeProfilingIntegration
+const release =
+	process.env.SENTRY_RELEASE ??
+	process.env.EPICSHOP_APP_COMMIT_SHA ??
+	process.env.EPICSHOP_APP_VERSION
 
 // Only initialize Sentry if we successfully imported the required modules
 Sentry?.init({
 	dsn: process.env.SENTRY_DSN,
 	sendDefaultPii: true,
 	environment: process.env.NODE_ENV ?? 'development',
+	release,
 	denyUrls: [
 		/\/resources\/healthcheck/,
 		/\/build\//,

--- a/packages/workshop-utils/src/env.server.ts
+++ b/packages/workshop-utils/src/env.server.ts
@@ -18,6 +18,7 @@ const schema = z
 		EPICSHOP_GITHUB_REPO: z.string().default(''),
 		EPICSHOP_GITHUB_ROOT: z.string().default(''),
 		EPICSHOP_APP_VERSION: z.string().optional(),
+		EPICSHOP_APP_COMMIT_SHA: z.string().optional(),
 		EPICSHOP_PARENT_PORT: z.string().optional(),
 		EPICSHOP_PARENT_TOKEN: z.string().optional(),
 		EPICSHOP_APP_LOCATION: z.string().optional(),
@@ -34,6 +35,7 @@ const schema = z
 		SENTRY_ORG: z.string().default('kent-c-dodds-tech-llc'),
 		SENTRY_PROJECT: z.string().default('epicshop'),
 		SENTRY_PROJECT_ID: z.string().default('4509630082252800'),
+		SENTRY_RELEASE: z.string().optional(),
 	})
 	.transform(async (env) => {
 		if (env.EPICSHOP_CONTEXT_CWD === '') {
@@ -150,11 +152,13 @@ export function getEnv() {
 			process.env.EPICSHOP_DEPLOYED === 'true' ||
 			process.env.EPICSHOP_DEPLOYED === '1',
 		EPICSHOP_APP_VERSION: process.env.EPICSHOP_APP_VERSION,
+		EPICSHOP_APP_COMMIT_SHA: process.env.EPICSHOP_APP_COMMIT_SHA,
 		EPICSHOP_PARENT_PORT: process.env.EPICSHOP_PARENT_PORT,
 		EPICSHOP_PARENT_TOKEN: process.env.EPICSHOP_PARENT_TOKEN,
 		EPICSHOP_IS_PUBLISHED: process.env.EPICSHOP_IS_PUBLISHED === 'true',
 		SENTRY_DSN: process.env.SENTRY_DSN,
 		SENTRY_PROJECT_ID: process.env.SENTRY_PROJECT_ID,
+		SENTRY_RELEASE: process.env.SENTRY_RELEASE,
 	}
 }
 


### PR DESCRIPTION
Align Sentry release configuration across build and runtime to ensure sourcemaps are uploaded and matched correctly.

The previous setup used a build-time release for sourcemap uploads, but the client-side SDKs didn't consistently set the `release` property, leading to mismatches. This PR ensures the `release` is consistently derived from `SENTRY_RELEASE`, `EPICSHOP_APP_COMMIT_SHA`, or `EPICSHOP_APP_VERSION` for both upload and runtime initialization, and makes these values available to the client. It also clarifies the necessary Sentry environment variables for successful sourcemap uploads.

---
<a href="https://cursor.com/background-agent?bcId=bc-4db8efc6-23b3-4918-8dad-5f04d336b33a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4db8efc6-23b3-4918-8dad-5f04d336b33a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures consistent Sentry release matching for sourcemaps across build and runtime.
> 
> - Client (`app/utils/monitoring.client.ts`) and server (`instrument.js`) now set `release` from `SENTRY_RELEASE` → `EPICSHOP_APP_COMMIT_SHA` → `EPICSHOP_APP_VERSION`
> - Vite config refactored to function form; Sentry plugin configured with conditional `release` and sourcemap cleanup; enabled only in production when `SENTRY_AUTH_TOKEN` is present
> - Environment handling (`workshop-utils/src/env.server.ts`) adds `SENTRY_RELEASE` and `EPICSHOP_APP_COMMIT_SHA` to schema and exposes them via `getEnv`
> - Docs (`docs/cli.md`) list new Sentry variables for sourcemap uploads: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_RELEASE`, and `EPICSHOP_APP_COMMIT_SHA`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cc36f149650e555c88e3108b125b2cd2a31a87c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->