### PR TITLE
Picture-in-picture method error

### DIFF
--- a/packages/workshop-app/app/utils/keyboard-shortcuts.client.ts
+++ b/packages/workshop-app/app/utils/keyboard-shortcuts.client.ts
@@ -338,8 +338,11 @@ function handleKeyDown(e: KeyboardEvent) {
 			e.preventDefault()
 			if (document.pictureInPictureElement) {
 				void document.exitPictureInPicture().catch(() => {})
-			} else {
-				void muxPlayer?.media?.requestPictureInPicture()
+			} else if (
+				muxPlayer.media &&
+				'requestPictureInPicture' in muxPlayer.media
+			) {
+				void (muxPlayer.media as HTMLVideoElement).requestPictureInPicture()
 			}
 		}
 		// arrow up/down to adjust volume


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-6519eafe-043d-4765-8fd1-31905396f7ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6519eafe-043d-4765-8fd1-31905396f7ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of the PiP keyboard shortcut on mux-player.
> 
> - In `keyboard-shortcuts.client.ts`, the 'i' hotkey now checks that `muxPlayer.media` exists and supports `requestPictureInPicture` before invoking it; otherwise exits PiP if active
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7fddafad5c6ac4bed2be8358306d574a7c5770b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->