### PR TITLE
Windows platform issue

### DIFF
--- a/example/exercises/01.exercise-navigation/01.problem.first-step/README.mdx
+++ b/example/exercises/01.exercise-navigation/01.problem.first-step/README.mdx
@@ -71,8 +71,9 @@ The editor selection algorithm uses a priority cascade. It first checks the
 `EPICSHOP_EDITOR` environment variable; if set, it uses that. Otherwise, it
 detects running editors by scanning active processes: on macOS it runs `ps x`
 and matches against a map of common editor process paths; on Windows it uses
-`wmic` to list processes and checks executable names against a whitelist; on
-Linux it uses `ps x` with process name filtering. The first matching editor from
+`wmic` when available (with a PowerShell `Get-Process` fallback) to list
+processes and checks executable names against a whitelist; on Linux it uses
+`ps x` with process name filtering. The first matching editor from
 the platform-specific list is selected.
 
 If no running editor is detected, the algorithm falls back to the `VISUAL`


### PR DESCRIPTION
Add a PowerShell fallback for Windows process detection to prevent editor auto-detection failures when `wmic.exe` is unavailable.

---
<a href="https://cursor.com/background-agent?bcId=bc-92b29d5d-b7be-4e02-8946-18b7b7615792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92b29d5d-b7be-4e02-8946-18b7b7615792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Windows editor auto-detection reliability.
> 
> - Introduces `getWindowsProcessPaths()` using `wmic` when present, with a PowerShell `Get-Process` fallback; `guessEditor()` now uses this to detect running editors via executable paths against a whitelist
> - Updates `README.mdx` to document the Windows detection fallback
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4768a4aa0ef10ddaa2bbfa144169ee3423f95ac0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->