### PR TITLE
Cleanup command loading state

### DIFF
--- a/packages/workshop-cli/src/commands/cleanup.ts
+++ b/packages/workshop-cli/src/commands/cleanup.ts
@@ -878,7 +878,6 @@ export async function cleanup({
 					(total, workshop) => total + workshop.cacheBytes,
 					0,
 				)
-				const offlineVideoIndex = await readOfflineVideoIndex(offlineVideosDir)
 				const selectionSpinner = startSpinner(
 					'Calculating workshop cleanup sizes...',
 					silent,


### PR DESCRIPTION
Add spinners to the `cleanup` command to provide feedback during long-running data analysis.

---
<a href="https://cursor.com/background-agent?bcId=bc-ffcdd645-cd72-43bd-bfbf-ac5082d0f2d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ffcdd645-cd72-43bd-bfbf-ac5082d0f2d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves UX of `cleanup` by showing real-time progress during potentially long operations.
> 
> - Introduces `ora` spinners with helper utilities and integrates them across analysis phases: resolving paths, listing workshops, calculating workshop/cache/offline-video sizes, scanning preferences/auth, and checking for unpushed changes
> - Extends `getWorkshopSummaries` with optional `onProgress` to report per-workshop progress while computing sizes
> - Minor refactor to compute and present size summaries before prompts; deletion logic remains the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f91ff46b29b674af46023105a333d378a5df7105. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->