### PR TITLE
Workshop display and access

### DIFF
--- a/packages/workshop-cli/src/commands/workshops.test.ts
+++ b/packages/workshop-cli/src/commands/workshops.test.ts
@@ -142,4 +142,3 @@ test('workshops start treats Ctrl+C (signal termination) as success', async () =
 		await fs.rm(workshopDir, { recursive: true, force: true })
 	}
 })
-


### PR DESCRIPTION
Improve workshop metadata fetching to correctly display icons, titles, and access information.

Previously, `package.json` metadata fetches were failing due to reliance on a single raw GitHub URL. This PR implements a more robust fetching strategy by trying multiple default branch URLs and falling back to the GitHub API, ensuring metadata is consistently retrieved. Failed fetches now have a short TTL for quicker retries.

---
<a href="https://cursor.com/background-agent?bcId=bc-e957d375-99a0-426e-bb7f-80876e8748d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e957d375-99a0-426e-bb7f-80876e8748d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens workshop metadata retrieval and cleans up host handling.
> 
> - Add `default_branch` to GitHub repo schema and use it when building raw `package.json` URLs; try `default_branch`, `main`, `master`, then fall back to `GET /repos/:org/:repo/contents/package.json` with `application/vnd.github.raw`
> - Introduce helpers (`getGitHubHeadersWithAccept`, `buildRawPackageJsonUrls`, `parsePackageJsonResponse`, `fetchPackageJsonFromUrl`) and adjust caching to short TTL on failures for quicker retries
> - Normalize `product.host` to canonical `www.*` domains via `normalizeProductHost` and apply in enrichment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a4ade016dd617068452eaacee36591418943b3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->