### PR TITLE
Exports console output whitespace

### DIFF
--- a/packages/workshop-app/public/export-app.css
+++ b/packages/workshop-app/public/export-app.css
@@ -63,6 +63,7 @@
 /* Console Entry Styles */
 .console-entry {
 	display: flex;
+	flex-direction: column;
 	align-items: flex-start;
 	gap: 0.5rem;
 	padding: 0.375rem 0.5rem;
@@ -178,6 +179,8 @@
 	flex: 1;
 	word-break: break-word;
 	color: #1f2937;
+	white-space: pre-wrap;
+	width: 100%;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -224,6 +227,7 @@
 .export-value {
 	flex: 1;
 	word-break: break-word;
+	white-space: pre-wrap;
 }
 
 .export-empty {


### PR DESCRIPTION
Preserve whitespace in console and export outputs and stack console log labels above their content to accurately display formatting.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d4d4a63-eda1-49be-a13b-f8019745ae9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d4d4a63-eda1-49be-a13b-f8019745ae9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability of console and export outputs.
> 
> - Set `.console-entry` to `flex-direction: column` to stack log labels above content
> - Preserve formatting by adding `white-space: pre-wrap` to `.console-content` and `.export-value`
> - Ensure content fills container with `width: 100%` on `.console-content`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe26297854b19848eeda578f366e3feca1d4a7bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->