### PR TITLE
Export properties display

### DIFF
--- a/packages/workshop-app/public/export-app.css
+++ b/packages/workshop-app/public/export-app.css
@@ -192,20 +192,15 @@
 /* Export Entry Styles */
 .export-entry {
 	display: flex;
+	flex-direction: column;
 	align-items: flex-start;
 	gap: 0.25rem;
-	padding: 0.5rem 0;
-	border-bottom: 1px solid #f3f4f6;
+	padding: 0.25rem 0;
+	margin-bottom: 0.75rem;
 }
 
 .export-entry:last-child {
-	border-bottom: none;
-}
-
-@media (prefers-color-scheme: dark) {
-	.export-entry {
-		border-bottom-color: #374151;
-	}
+	margin-bottom: 0;
 }
 
 .export-name {
@@ -221,13 +216,14 @@
 }
 
 .export-colon {
-	color: #6b7280;
+	display: none;
 }
 
 .export-value {
 	flex: 1;
 	word-break: break-word;
 	white-space: pre-wrap;
+	padding-left: 0.75rem;
 }
 
 .export-empty {


### PR DESCRIPTION
Refactor export entry styling to display property names and values on separate lines with indentation and spacing to improve readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-afdda8ab-82d4-4ec9-b992-88113822d1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-afdda8ab-82d4-4ec9-b992-88113822d1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines `export-entry` layout to show property names and values on separate lines with clearer spacing.
> 
> - Switches `export-entry` to column layout; reduces padding and adds bottom margins
> - Removes per-entry borders and related dark-mode styles
> - Hides `export-colon` and adds left padding to `export-value` for indentation
> - Keeps color tweaks for `export-name`; no JS/logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1ddd59b85710bfbbb57a3df3149a8c3406f9122. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->