### PR TITLE
Nav exercises numbering format

### DIFF
--- a/packages/workshop-app/app/routes/_app+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/_layout.tsx
@@ -846,6 +846,9 @@ function MobileNavigation({
 									</NavLink>
 								</span>
 								{data.exercises.map(({ exerciseNumber, title, steps }) => {
+									const exerciseNumberLabel = exerciseNumber
+										.toString()
+										.padStart(2, '0')
 									const isActive =
 										Number(params.exerciseNumber) === exerciseNumber
 									const showPlayground =
@@ -866,7 +869,10 @@ function MobileNavigation({
 														{ 'bg-foreground text-background': isActive },
 													)}
 												>
-													{title}
+													<span className="text-muted-foreground tabular-nums">
+														{exerciseNumberLabel}.
+													</span>{' '}
+													<span>{title}</span>
 												</Link>
 												{showPlayground ? (
 													<Link
@@ -1436,6 +1442,9 @@ function Navigation({
 									</NavLink>
 								</span>
 								{data.exercises.map(({ exerciseNumber, title, steps }) => {
+									const exerciseNumberLabel = exerciseNumber
+										.toString()
+										.padStart(2, '0')
 									const isActive =
 										Number(params.exerciseNumber) === exerciseNumber
 									const showPlayground =
@@ -1456,7 +1465,10 @@ function Navigation({
 														{ 'bg-foreground text-background': isActive },
 													)}
 												>
-													{title}
+													<span className="text-muted-foreground tabular-nums">
+														{exerciseNumberLabel}.
+													</span>{' '}
+													<span>{title}</span>
 												</Link>
 												{showPlayground ? (
 													<Link


### PR DESCRIPTION
Add leading zeros to exercise numbers in the navigation to display them as "01.", "02.", etc.

---
<a href="https://cursor.com/background-agent?bcId=bc-53aedd1e-e584-4373-9399-f76d432936e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-53aedd1e-e584-4373-9399-f76d432936e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds leading-zero numbering to exercise links in both mobile and desktop navigation.
> 
> - Prefixes exercise titles with `NN.` using `padStart(2, '0')` and styles the number with `text-muted-foreground tabular-nums`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0a9cefc5a01b42cc5f50a18676ca1469373a0d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->