### PR TITLE
Trimmer timeline zoom

### DIFF
--- a/packages/workshop-app/app/components/epic-video.tsx
+++ b/packages/workshop-app/app/components/epic-video.tsx
@@ -849,7 +849,9 @@ function EpicVideo({
 					/>
 				)}
 			</div>
-			<TimelineZoom className="mt-3" mediaRef={timelineMediaRef} />
+			{(shouldUseOfflineVideo || isOnline) && (
+				<TimelineZoom className="mt-3" mediaRef={timelineMediaRef} />
+			)}
 			<div className="mt-4 flex flex-col gap-2">
 				<VideoLink
 					url={urlString}

--- a/packages/workshop-app/app/components/timeline-zoom.tsx
+++ b/packages/workshop-app/app/components/timeline-zoom.tsx
@@ -41,9 +41,9 @@ export function TimelineZoom({ mediaRef, className }: TimelineZoomProps) {
 	const [currentTime, setCurrentTime] = React.useState(0)
 	const [zoom, setZoom] = React.useState(1)
 	const [windowStart, setWindowStart] = React.useState(0)
-	const mediaElement = mediaRef.current
 
 	React.useEffect(() => {
+		const mediaElement = mediaRef.current
 		if (!mediaElement) return
 		const updateDuration = () => {
 			const nextDuration = Number.isFinite(mediaElement.duration)
@@ -70,7 +70,7 @@ export function TimelineZoom({ mediaRef, className }: TimelineZoomProps) {
 			mediaElement.removeEventListener?.('durationchange', updateDuration)
 			mediaElement.removeEventListener?.('loadedmetadata', updateDuration)
 		}
-	}, [mediaElement])
+	}, [mediaRef])
 
 	const safeDuration = Number.isFinite(duration) ? duration : 0
 	const maxZoom = safeDuration


### PR DESCRIPTION
Add a timeline zoom component to the video trimmer page to enable precise navigation and trimming.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4def6da-2302-4f5c-b232-46b1a41e43a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4def6da-2302-4f5c-b232-46b1a41e43a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a timeline zoom UI to improve precise navigation in the video player.
> 
> - New `TimelineZoom` component (`components/timeline-zoom.tsx`) with zoom level, window pan, and playhead scrub controls; syncs with media via `timeupdate`/`durationchange`/`loadedmetadata` and clamps values based on duration
> - Integrated into `epic-video.tsx`: selects `mediaRef` from native `<video>` (offline) or `MuxPlayer` ref (online), and renders `TimelineZoom` when media is playable (online or offline available)
> - Minor wiring: compute `timelineMediaRef`, show component below player, non-intrusive to existing playback/download logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56169053b7675245a0de0434a2665f576b09bd88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->