### PR TITLE
Exercise label appearance

### DIFF
--- a/packages/workshop-app/app/routes/_app+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/_layout.tsx
@@ -869,7 +869,7 @@ function MobileNavigation({
 														{ 'bg-foreground text-background': isActive },
 													)}
 												>
-													<span className="text-muted-foreground tabular-nums text-xs align-super mr-1">
+													<span className="text-muted-foreground mr-1 align-super text-xs tabular-nums">
 														{exerciseNumberLabel}.
 													</span>
 													<span>{title}</span>
@@ -1465,7 +1465,7 @@ function Navigation({
 														{ 'bg-foreground text-background': isActive },
 													)}
 												>
-													<span className="text-muted-foreground tabular-nums text-xs align-super mr-1">
+													<span className="text-muted-foreground mr-1 align-super text-xs tabular-nums">
 														{exerciseNumberLabel}.
 													</span>
 													<span>{title}</span>


### PR DESCRIPTION
Make nav exercise number labels smaller text with a bit of space, as they are more of a footnote reference.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5c33ced-ae1b-45e9-a0ba-5c71691060ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c5c33ced-ae1b-45e9-a0ba-5c71691060ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the visual treatment of exercise numbers in navigation.
> 
> - Updates `span` around `exerciseNumberLabel` to use `text-xs`, `align-super`, and `mr-1`; removes trailing space for cleaner layout
> - Applied in both mobile and desktop exercise lists within `_app+/_layout.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2de540789abbc7a70d5f0fd79eb013344c351933. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->