### PR TITLE
Playground automatic revalidation

### DIFF
--- a/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
@@ -38,7 +38,7 @@ import { EditFileOnGitHub } from '#app/routes/launch-editor.tsx'
 import { ProgressToggle } from '#app/routes/progress.tsx'
 import { SetAppToPlayground } from '#app/routes/set-playground.tsx'
 import { getExercisePath } from '#app/utils/misc.tsx'
-import { getRootMatchLoaderData } from '#app/utils/root-loader.ts'
+import { getRootMatchLoaderData, useApps } from '#app/utils/root-loader.ts'
 import { getSeoMetaTags } from '#app/utils/seo.ts'
 import {
 	getSplitPercentFromRequest,
@@ -292,6 +292,7 @@ export const headers: HeadersFunction = ({ loaderHeaders, parentHeaders }) => {
 export default function ExercisePartRoute({
 	loaderData: data,
 }: Route.ComponentProps) {
+	const apps = useApps()
 	const inBrowserBrowserRef = useRef<InBrowserBrowserRef>(null)
 	const containerRef = useRef<HTMLDivElement>(null)
 	const leftPaneRef = useRef<HTMLDivElement>(null)
@@ -299,8 +300,15 @@ export default function ExercisePartRoute({
 
 	const titleBits = pageTitle(data)
 
+	const playgroundBasePath = apps.find(
+		(app) => app.name === data.playground?.appName,
+	)?.fullPath
+
 	useRevalidationWS({
-		watchPaths: [`${data.exerciseStepApp.relativePath}/README.mdx`],
+		watchPaths: [
+			`${data.exerciseStepApp.relativePath}/README.mdx`,
+			playgroundBasePath,
+		].filter((path): path is string => Boolean(path)),
 	})
 
 	const showPlaygroundIndicator = data.problem

--- a/packages/workshop-app/app/routes/_app+/extra+/$extra.tsx
+++ b/packages/workshop-app/app/routes/_app+/extra+/$extra.tsx
@@ -51,6 +51,7 @@ import { fetchDiscordPosts } from '#app/utils/discord.server.ts'
 import { createInlineFileComponent, Mdx } from '#app/utils/mdx.tsx'
 import {
 	getRootMatchLoaderData,
+	useApps,
 	useRootLoaderData,
 } from '#app/utils/root-loader.ts'
 import { getSeoMetaTags } from '#app/utils/seo.ts'
@@ -222,6 +223,7 @@ export const headers: HeadersFunction = ({ loaderHeaders, parentHeaders }) => {
 export default function ExtraRoute() {
 	const data = useLoaderData<typeof loader>()
 	const rootData = useRootLoaderData()
+	const apps = useApps()
 	const inBrowserBrowserRef = useRef<InBrowserBrowserRef>(null)
 	const containerRef = useRef<HTMLDivElement>(null)
 	const leftPaneRef = useRef<HTMLDivElement>(null)
@@ -310,8 +312,14 @@ export default function ExtraRoute() {
 		}
 	}, [data.extra.name, data.extra.fullPath])
 
+	const playgroundBasePath = apps.find(
+		(app) => app.name === data.playground?.appName,
+	)?.fullPath
+
 	useRevalidationWS({
-		watchPaths: [data.extraReadme.file],
+		watchPaths: [data.extraReadme.file, playgroundBasePath].filter(
+			(path): path is string => Boolean(path),
+		),
 	})
 
 	return (


### PR DESCRIPTION
Automatically revalidate playground status when the associated base app files change to eliminate manual refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-536afbd9-d627-4072-8b03-91bb5e23ad89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-536afbd9-d627-4072-8b03-91bb5e23ad89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automatically refreshes playground status when underlying app files change.
> 
> - Imports `useApps` to resolve `playgroundBasePath` and adds it to `useRevalidationWS` `watchPaths`
> - Applies to both exercise step layout (`_layout.tsx`) and extras route (`$extra.tsx`) to trigger revalidation without manual refresh
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1448b871060b3430d205b98c232cbffba90f33b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->