### PR TITLE
Issue 546 problem

### DIFF
--- a/packages/workshop-utils/src/package-install/package-install-check.server.test.ts
+++ b/packages/workshop-utils/src/package-install/package-install-check.server.test.ts
@@ -439,6 +439,33 @@ describe('getRootPackageJsonPaths', () => {
 		expect(paths).toContain(path.resolve(subDir, 'package.json'))
 	})
 
+	test('ignores playground and saved-playgrounds package.json files', async () => {
+		await writePackageJson(tempDir, {
+			name: 'root-package',
+		})
+
+		const playgroundDir = path.join(tempDir, 'playground')
+		await fs.mkdir(playgroundDir, { recursive: true })
+		await writePackageJson(playgroundDir, {
+			name: 'playground-package',
+		})
+
+		const savedPlaygroundDir = path.join(
+			tempDir,
+			'saved-playgrounds',
+			'2026.01.27_11.35.51_01.01.problem',
+		)
+		await fs.mkdir(savedPlaygroundDir, { recursive: true })
+		await writePackageJson(savedPlaygroundDir, {
+			name: 'saved-playground-package',
+		})
+
+		const paths = await getRootPackageJsonPaths(tempDir)
+
+		expect(paths).toHaveLength(1)
+		expect(paths[0]).toBe(path.resolve(tempDir, 'package.json'))
+	})
+
 	test('handles workspaces defined as object', async () => {
 		await writePackageJson(tempDir, {
 			name: 'root-package',

--- a/packages/workshop-utils/src/package-install/package-install-check.server.ts
+++ b/packages/workshop-utils/src/package-install/package-install-check.server.ts
@@ -48,6 +48,8 @@ const workspaceIgnorePatterns = [
 	'**/dist/**',
 	'**/build/**',
 	'**/coverage/**',
+	'**/playground/**',
+	'**/saved-playgrounds/**',
 ]
 
 function hashString(value: string) {


### PR DESCRIPTION
Ignore `playground` and `saved-playgrounds` directories during dependency root scanning to prevent unwanted package installations in generated app copies, addressing GitHub issue #546.

Closes #546 

---
<a href="https://cursor.com/background-agent?bcId=bc-69382484-2848-49c7-9433-e285ab364092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69382484-2848-49c7-9433-e285ab364092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents `package.json` files under generated app copies from being treated as roots.
> 
> - Updates `workspaceIgnorePatterns` to exclude `**/playground/**` and `**/saved-playgrounds/**` during package root scanning
> - Adds test ensuring `getRootPackageJsonPaths` ignores these directories
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f519172dabc5e360f082adf966a49b5d794d9b49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->