### PR TITLE
Epicshop cleanup workshop scope

### DIFF
--- a/packages/workshop-cli/src/commands/cleanup.ts
+++ b/packages/workshop-cli/src/commands/cleanup.ts
@@ -12,7 +12,6 @@ import {
 } from '@epic-web/workshop-utils/data-storage.server'
 import {
 	deleteWorkshop,
-	getConfigPath,
 	getReposDirectory,
 	getUnpushedChanges,
 } from '@epic-web/workshop-utils/workshops.server'
@@ -171,14 +170,9 @@ async function resolveCleanupPaths(
 	]
 	const offlineVideosDir =
 		paths.offlineVideosDir ?? path.join(resolvePrimaryDir(), 'offline-videos')
-	let configPath = paths.configPath
-	if (!configPath) {
-		try {
-			configPath = getConfigPath()
-		} catch {
-			configPath = path.join(resolvePrimaryDir(), 'workshops-config.json')
-		}
-	}
+	const configPath =
+		paths.configPath ??
+		path.join(resolvePrimaryDir(), 'workshops-config.json')
 	return {
 		reposDir,
 		cacheDir,


### PR DESCRIPTION
Optimizes the `cleanup` command to defer workshop and other target size calculations until they are explicitly needed, preventing unnecessary full scans.

Previously, running `npx epicshop cleanup --workshops <name> --workshop-actions caches` would trigger a full scan of all installed workshops to calculate their sizes, even though only a specific workshop's caches were targeted. This PR addresses that by deferring size calculations until they are explicitly needed for display or action on the selected items. It also fixes an issue with `getConfigPath` resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6318aa7-66f2-4f15-b078-ecc6a6b70cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c6318aa7-66f2-4f15-b078-ecc6a6b70cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deletion tooling and filesystem path resolution; incorrect lazy-loading/size gating or the new config path could lead to misleading size output or cleaning the wrong config file, though core deletion behavior is largely unchanged.
> 
> **Overview**
> The `cleanup` command now **defers expensive disk scans** (workshop size summaries, caches/offline-video sizes, preferences/auth data diffs) until they’re required for interactive display or selected cleanup actions, avoiding full inventory/size calculation when users target specific workshops/actions.
> 
> It also introduces a lightweight `WorkshopIdentity` (path/title/repoName + `id`) to allow workshop selection without precomputing sizes, lazily loads the offline video index only when relevant, and changes `configPath` resolution to use `resolvePrimaryDir()/workshops-config.json` instead of `getConfigPath()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5087e94a55041f9af34cfeaa715254a00cdada5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->