### PR TITLE
Admin cache lazy loading

### DIFF
--- a/packages/workshop-app/app/routes/admin+/cache.tsx
+++ b/packages/workshop-app/app/routes/admin+/cache.tsx
@@ -428,13 +428,7 @@ function InlineEntryEditor({
 			<div className="border-border bg-muted mt-2 space-y-3 rounded border p-3">
 				{isEntryLoading ? (
 					<p className="text-muted-foreground text-sm">Loading entry...</p>
-				) : null}
-				{entryMissing ? (
-					<p className="text-destructive text-sm">
-						Entry details were not found.
-					</p>
-				) : null}
-				{entryFetchFailed ? (
+				) : entryFetchFailed ? (
 					<div className="space-y-2">
 						<p className="text-destructive text-sm">
 							Failed to load entry details.
@@ -443,13 +437,11 @@ function InlineEntryEditor({
 							Retry
 						</Button>
 					</div>
-				) : null}
-				{!hasEntry && !isEntryLoading && !entryMissing && !entryFetchFailed ? (
-					<p className="text-muted-foreground text-sm">
-						Open to load entry details.
+				) : entryMissing ? (
+					<p className="text-destructive text-sm">
+						Entry details were not found.
 					</p>
-				) : null}
-				{hasEntry ? (
+				) : hasEntry ? (
 					<>
 						<div>
 							<label className="mb-1 block text-sm font-medium">Key:</label>
@@ -483,7 +475,11 @@ function InlineEntryEditor({
 							</Button>
 						</div>
 					</>
-				) : null}
+				) : (
+					<p className="text-muted-foreground text-sm">
+						Open to load entry details.
+					</p>
+				)}
 			</div>
 		</details>
 	)


### PR DESCRIPTION
Lazy-load cache entry values and enable server-side filtering on `/admin/cache` to improve performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-c844a127-760b-49ef-8e52-85e8763be30c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c844a127-760b-49ef-8e52-85e8763be30c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `/admin/cache` data shaping and fetch behavior, which may affect what entries appear in results and introduces new async UI states for editing/saving cache entries.
> 
> **Overview**
> Improves `/admin/cache` performance by **not returning full cache entry payloads in the page list**; the loader now returns lightweight entry info (key/filename/size/filepath/metadata) and the inline editor **lazy-loads the entry value on demand** when expanded, with explicit loading/error/missing/retry states.
> 
> Enhances server-side filtering by normalizing the search query and matching against cache name, entry key, and (when possible) a serialized entry value, while filtering out empty caches/workshops only when a query is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1fa1e6199e43008209e88e86d094045cbdb0d93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->