### PR TITLE
Step page header overflow

### DIFF
--- a/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
@@ -326,7 +326,7 @@ export default function ExercisePartRoute({
 					style={{ ['--split-pct' as any]: `${splitPercent}%` }}
 					ref={leftPaneRef}
 				>
-					<h1 className="@container h-14 max-w-full overflow-x-auto overflow-y-hidden border-b pr-5 pl-10 text-sm leading-tight font-medium scrollbar-thin scrollbar-thumb-scrollbar">
+					<h1 className="scrollbar-thin scrollbar-thumb-scrollbar @container h-14 max-w-full overflow-x-auto overflow-y-hidden border-b pr-5 pl-10 text-sm leading-tight font-medium">
 						<div className="flex h-14 items-center justify-between gap-x-2 py-2 whitespace-nowrap">
 							<div className="flex items-center justify-start gap-x-2 uppercase">
 								<Link


### PR DESCRIPTION
Add horizontal scrolling to the step page header to prevent text overflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1c1232f-17a8-45b9-9d0d-2003ffcc5214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1c1232f-17a8-45b9-9d0d-2003ffcc5214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational CSS/class changes to a single route layout; no data flow or logic changes.
> 
> **Overview**
> Prevents long exercise/step titles from overflowing the step page header by enabling horizontal scrolling on the `<h1>` container.
> 
> This adds `overflow-x-auto`/`max-w-full` plus thin scrollbar styling, while keeping the header height fixed and vertical overflow hidden.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b95ca6bdd019d144c480f22ce2f70243e1d17ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->