### PR TITLE
Clarify workshop directory search errors

### DIFF
--- a/packages/workshop-mcp/src/utils.test.ts
+++ b/packages/workshop-mcp/src/utils.test.ts
@@ -164,8 +164,12 @@ test('handleWorkshopDirectory normalizes playground to workshop root', async () 
 test('handleWorkshopDirectory rejects when no workshop directory found (aha)', async () => {
 	await using fixture = await createTempDir()
 	vi.mocked(console.error).mockImplementation(() => {})
+	const searchStartDirectory = path.join(fixture.root, 'nested', 'deeper')
+	const filesystemRoot = path.parse(searchStartDirectory).root
 
-	await expect(handleWorkshopDirectory(fixture.root)).rejects.toThrow(
-		/No workshop directory found/,
+	await mkdir(searchStartDirectory, { recursive: true })
+
+	await expect(handleWorkshopDirectory(searchStartDirectory)).rejects.toThrow(
+		`No workshop directory found while searching upward from "${searchStartDirectory}" to filesystem root "${filesystemRoot}"`,
 	)
 })

--- a/packages/workshop-mcp/src/utils.ts
+++ b/packages/workshop-mcp/src/utils.ts
@@ -48,10 +48,14 @@ export async function handleWorkshopDirectory(workshopDirectory: string) {
 		workshopDirectory = path.join(workshopDirectory, '..')
 	}
 
+	const searchStartDirectory = workshopDirectory
+
 	while (true) {
 		if (await isWorkshopDirectory(workshopDirectory)) break
 		if (workshopDirectory === path.dirname(workshopDirectory)) {
-			throw new Error(`No workshop directory found in "${workshopDirectory}"`)
+			throw new Error(
+				`No workshop directory found while searching upward from "${searchStartDirectory}" to filesystem root "${workshopDirectory}"`,
+			)
 		}
 		workshopDirectory = path.dirname(workshopDirectory)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve the normalized starting directory before walking parents in `handleWorkshopDirectory`
- clarify the thrown error so it says the search walked upward to the filesystem root
- tighten the MCP utils test to cover a nested non-workshop directory and assert the new message

## Testing
- `npm --prefix packages/workshop-mcp test -- src/utils.test.ts`
- `npm --prefix packages/workshop-mcp run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f99cdd3d-f96e-4749-8b2c-85c8596cdd25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f99cdd3d-f96e-4749-8b2c-85c8596cdd25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

