### PR TITLE
Fix ByteString error in PE redirect statusText

### DIFF
--- a/packages/workshop-app/app/utils/pe.tsx
+++ b/packages/workshop-app/app/utils/pe.tsx
@@ -56,8 +56,31 @@ export function dataWithPE<Data>(
 	...args: Parameters<typeof data<Data>>
 ) {
 	ensureProgressiveEnhancement(request, formData, () => ({
-		statusText: JSON.stringify(args[0]),
+		statusText: serializeStatusText(args[0]),
 		...(typeof args[1] === 'number' ? { status: args[1] } : args[1]),
 	}))
 	return data(...args)
+}
+
+function serializeStatusText(value: unknown) {
+	const json = JSON.stringify(value) ?? ''
+	let result = ''
+	for (const char of json) {
+		const codePoint = char.codePointAt(0) ?? 0
+		if (codePoint <= 0xff) {
+			result += char
+			continue
+		}
+		if (codePoint <= 0xffff) {
+			result += `\\u${codePoint.toString(16).padStart(4, '0')}`
+			continue
+		}
+		const offset = codePoint - 0x10000
+		const high = 0xd800 + Math.floor(offset / 0x400)
+		const low = 0xdc00 + (offset % 0x400)
+		result += `\\u${high.toString(16).padStart(4, '0')}\\u${low
+			.toString(16)
+			.padStart(4, '0')}`
+	}
+	return result
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- escape non-ASCII characters when serializing PE statusText for redirects
- prevent ByteString conversion errors from malformed form data

## Testing
- `curl -i -X POST "http://localhost:5639/theme" -H "Accept: text/html" --data-urlencode "__PE_redirectTo=/exercise/04/01/problem" --data-urlencode "intent=update-theme-😀" --data-urlencode "theme=system"`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-165487a1-cc67-498d-a6a5-1a70ac40cbea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-165487a1-cc67-498d-a6a5-1a70ac40cbea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

