### PR TITLE
Fix quizMe exercise selection for missing input

### DIFF
--- a/packages/workshop-mcp/src/prompts.ts
+++ b/packages/workshop-mcp/src/prompts.ts
@@ -1,3 +1,4 @@
+import { invariant } from '@epic-web/invariant'
 import { getExercises } from '@epic-web/workshop-utils/apps.server'
 import { getWorkshopConfig } from '@epic-web/workshop-utils/config.server'
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
@@ -16,6 +17,7 @@ export const quizMeInputSchema: PromptInputSchema = {
 	workshopDirectory: workshopDirectoryInputSchema,
 	exerciseNumber: z
 		.string()
+		.trim()
 		.optional()
 		.describe(
 			'Exercise number to quiz on (e.g., "4"). Omit for a random exercise.',
@@ -31,8 +33,15 @@ export async function quizMe({
 }): Promise<GetPromptResult> {
 	const workshopRoot = await handleWorkshopDirectory(workshopDirectory)
 	const config = getWorkshopConfig()
-	let exerciseNumber = Number(providedExerciseNumber)
-	if (!providedExerciseNumber) {
+	let exerciseNumber: number | undefined
+	if (providedExerciseNumber) {
+		exerciseNumber = Number(providedExerciseNumber)
+		invariant(
+			Number.isFinite(exerciseNumber),
+			`Exercise number must be a number, received "${providedExerciseNumber}".`,
+		)
+	}
+	if (exerciseNumber === undefined) {
 		const exercises = await getExercises()
 		const randomExercise =
 			exercises[Math.floor(Math.random() * exercises.length)]

--- a/packages/workshop-mcp/src/quiz-me.test.ts
+++ b/packages/workshop-mcp/src/quiz-me.test.ts
@@ -1,0 +1,66 @@
+import { expect, test, vi } from 'vitest'
+import { quizMe } from './prompts.ts'
+import { exerciseContextResource } from './resources.ts'
+
+vi.mock('@epic-web/workshop-utils/apps.server', () => ({
+	getExercises: vi.fn(async () => [{ exerciseNumber: 3 }]),
+}))
+
+vi.mock('@epic-web/workshop-utils/config.server', () => ({
+	getWorkshopConfig: vi.fn(() => ({
+		title: 'Test Workshop',
+		subtitle: 'Testing Sub',
+	})),
+}))
+
+vi.mock('./resources.ts', () => ({
+	exerciseContextResource: {
+		getResource: vi.fn(async ({ exerciseNumber }: { exerciseNumber: number }) => ({
+			uri: `epicshop://exercise/${exerciseNumber}`,
+			mimeType: 'text/plain',
+			text: `exercise ${exerciseNumber}`,
+		})),
+	},
+}))
+
+vi.mock('./utils.ts', async () => {
+	const actual = await vi.importActual<typeof import('./utils.ts')>('./utils.ts')
+	return {
+		...actual,
+		handleWorkshopDirectory: vi.fn(async (workshopDirectory: string) => {
+			return workshopDirectory
+		}),
+	}
+})
+
+test('quizMe chooses a random exercise when none provided (aha)', async () => {
+	const resultPromise = quizMe({ workshopDirectory: '/workshop' })
+
+	await expect(resultPromise).resolves.toMatchObject({
+		messages: [
+			{ role: 'user', content: { type: 'text' } },
+			{ role: 'user', content: { type: 'resource' } },
+		],
+	})
+
+	const result = await resultPromise
+	const getResource = vi.mocked(exerciseContextResource.getResource)
+
+	expect(getResource).toHaveBeenCalledWith({
+		workshopDirectory: '/workshop',
+		exerciseNumber: 3,
+	})
+	expect(result.messages[0].content.type).toBe('text')
+	expect(result.messages[0].content.text).toContain('exercise 3')
+})
+
+test('quizMe rejects non-numeric exercise numbers (aha)', async () => {
+	const resultPromise = quizMe({
+		workshopDirectory: '/workshop',
+		exerciseNumber: 'not-a-number',
+	})
+
+	await expect(resultPromise).rejects.toThrow(
+		'Exercise number must be a number',
+	)
+})

--- a/packages/workshop-mcp/src/quiz-me.test.ts
+++ b/packages/workshop-mcp/src/quiz-me.test.ts
@@ -50,8 +50,12 @@ test('quizMe chooses a random exercise when none provided (aha)', async () => {
 		workshopDirectory: '/workshop',
 		exerciseNumber: 3,
 	})
-	expect(result.messages[0].content.type).toBe('text')
-	expect(result.messages[0].content.text).toContain('exercise 3')
+	const firstMessage = result.messages[0]
+	expect(firstMessage?.content.type).toBe('text')
+	if (!firstMessage || firstMessage.content.type !== 'text') {
+		throw new Error('Expected first message to be text')
+	}
+	expect(firstMessage.content.text).toContain('exercise 3')
 })
 
 test('quizMe rejects non-numeric exercise numbers (aha)', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- guard quizMe exercise parsing and pick random exercise when missing
- add quizMe test coverage for random selection and invalid numbers
- tighten quizMe test assertions to satisfy typecheck

## Testing
- `npm --prefix packages/workshop-mcp run typecheck`
- `npm --prefix packages/workshop-mcp run test -- quiz-me.test.ts`

## Evidence
<a href="https://cursor.com/agents/bc-7012f489-5ea6-4423-a7d9-0367718998ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquiz_me_typecheck_and_tests.mp4"><img src="https://cursor.com/artifacts/c/art-9a3b8544-7412-4d12-862a-99c07f02c5d2" alt="quiz_me_typecheck_and_tests.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7012f489-5ea6-4423-a7d9-0367718998ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7012f489-5ea6-4423-a7d9-0367718998ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

