### PR TITLE
Sanitize PE redirect locations for ByteString safety

### DIFF
--- a/packages/workshop-app/app/utils/pe.tsx
+++ b/packages/workshop-app/app/utils/pe.tsx
@@ -30,13 +30,13 @@ export function ensureProgressiveEnhancement(
 ) {
 	const redirectTo = formData.get(PE_REDIRECT_INPUT_NAME)
 	if (typeof redirectTo === 'string') {
-		throw redirect(safeRedirect(redirectTo), responseInit?.())
+		throw redirect(toRedirectLocation(redirectTo), responseInit?.())
 	}
 
 	// if request does not accept application/json, it means JS hasn't hydrated yet
 	if (!acceptsJson(request)) {
 		const redirectToReferrer = request.headers.get('Referer') ?? '/'
-		throw redirect(safeRedirect(redirectToReferrer), responseInit?.())
+		throw redirect(toRedirectLocation(redirectToReferrer), responseInit?.())
 	}
 }
 
@@ -48,6 +48,15 @@ function acceptsJson(request: Request) {
 		accept.includes('application/*') ||
 		accept.includes('*/json')
 	)
+}
+
+function toRedirectLocation(redirectTo: string, fallback = '/') {
+	const safe = safeRedirect(redirectTo, fallback)
+	try {
+		return encodeURI(safe)
+	} catch {
+		return fallback
+	}
 }
 
 export function dataWithPE<Data>(

--- a/packages/workshop-app/app/utils/pe.tsx
+++ b/packages/workshop-app/app/utils/pe.tsx
@@ -53,9 +53,13 @@ function acceptsJson(request: Request) {
 function toRedirectLocation(redirectTo: string, fallback = '/') {
 	const safe = safeRedirect(redirectTo, fallback)
 	try {
-		return encodeURI(safe)
+		return encodeURI(decodeURI(safe))
 	} catch {
-		return fallback
+		try {
+			return encodeURI(safe)
+		} catch {
+			return fallback
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- decode and re-encode progressive enhancement redirect locations to avoid double-encoding
- keep redirect sanitization while preserving percent-encoded paths

## Testing
- npm run test
- Manual: node check for encodeURI(decodeURI(safeRedirect('/foo%20bar')))

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-132e896e-5c84-4744-9dc4-9906e58054d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-132e896e-5c84-4744-9dc4-9906e58054d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

