### PR TITLE
Fix PE redirect percent encoding

### DIFF
--- a/packages/workshop-app/app/utils/pe.tsx
+++ b/packages/workshop-app/app/utils/pe.tsx
@@ -30,13 +30,13 @@ export function ensureProgressiveEnhancement(
 ) {
 	const redirectTo = formData.get(PE_REDIRECT_INPUT_NAME)
 	if (typeof redirectTo === 'string') {
-		throw redirect(safeRedirect(redirectTo), responseInit?.())
+		throw redirect(toRedirectLocation(redirectTo), responseInit?.())
 	}
 
 	// if request does not accept application/json, it means JS hasn't hydrated yet
 	if (!acceptsJson(request)) {
 		const redirectToReferrer = request.headers.get('Referer') ?? '/'
-		throw redirect(safeRedirect(redirectToReferrer), responseInit?.())
+		throw redirect(toRedirectLocation(redirectToReferrer), responseInit?.())
 	}
 }
 
@@ -48,6 +48,38 @@ function acceptsJson(request: Request) {
 		accept.includes('application/*') ||
 		accept.includes('*/json')
 	)
+}
+
+export function toRedirectLocation(redirectTo: string, fallback = '/') {
+	const safe = safeRedirect(redirectTo, fallback)
+	try {
+		return encodeURIWithoutDoubleEncoding(safe)
+	} catch {
+		return fallback
+	}
+}
+
+function encodeURIWithoutDoubleEncoding(value: string) {
+	let result = ''
+	let chunk = ''
+
+	for (let index = 0; index < value.length; index++) {
+		const char = value[index]
+		if (char === '%' && isHex(value[index + 1]) && isHex(value[index + 2])) {
+			result += encodeURI(chunk)
+			chunk = ''
+			result += value.slice(index, index + 3)
+			index += 2
+			continue
+		}
+		chunk += char
+	}
+
+	return result + encodeURI(chunk)
+}
+
+function isHex(value: string | undefined) {
+	return value ? /^[\da-f]$/i.test(value) : false
 }
 
 export function dataWithPE<Data>(

--- a/packages/workshop-app/tests/pe.browser.test.ts
+++ b/packages/workshop-app/tests/pe.browser.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'vitest'
+import { toRedirectLocation } from '#app/utils/pe.tsx'
+
+test('preserves already percent-encoded redirects', () => {
+	expect(toRedirectLocation('/foo%20bar')).toBe('/foo%20bar')
+})
+
+test('encodes non-ascii redirects for location header compatibility', () => {
+	expect(toRedirectLocation('/café')).toBe('/caf%C3%A9')
+})
+
+test('falls back for unsafe redirects', () => {
+	expect(toRedirectLocation('https://example.com/foo%20bar')).toBe('/')
+})
+
+test('falls back when redirects cannot be encoded', () => {
+	expect(toRedirectLocation('/\uD800')).toBe('/')
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Route progressive enhancement redirects through `toRedirectLocation` so already-percent-encoded paths are not double encoded.
- Add regression coverage for encoded paths, non-ASCII paths, unsafe redirects, and unencodable input.

## Testing
- `npx nx run @epic-web/workshop-app:build` passes.
- `npm --prefix packages/workshop-app run lint` passes.
- `npx tsx --conditions development -e "import { toRedirectLocation } from './packages/workshop-app/app/utils/pe.tsx'; const cases = [['/foo%20bar','/foo%20bar'], ['/café','/caf%C3%A9'], ['https://example.com/foo%20bar','/'], ['/'+String.fromCharCode(0xd800), '/']]; for (const [input, expected] of cases) { const actual = toRedirectLocation(input); if (actual !== expected) throw new Error(input + ' expected ' + expected + ' got ' + actual); console.log(input.replace(/\\ud800/g, '<surrogate>') + ' => ' + actual); }"` passes.
- `npm test` passed in the git pre-push hook: 21 files, 167 tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1a588fc-7367-4e3d-8d9a-5d759756d520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1a588fc-7367-4e3d-8d9a-5d759756d520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

