### PR TITLE
fix(workshop-utils): Windows path compatibility in diff pipeline

### DIFF
--- a/packages/workshop-utils/src/diff.server.ts
+++ b/packages/workshop-utils/src/diff.server.ts
@@ -97,6 +97,14 @@ const DEFAULT_IGNORE_PATTERNS = [
 	'**/epicshop/**',
 ]
 
+// On Windows, `path.relative` and `path.join` return backslash-separated
+// paths, but `git diff --no-index`, the `ignore` package, and the downstream
+// patch parser (`@pierre/diffs`) all expect POSIX-style forward slashes.
+// Normalizing here is what makes the diff pipeline work cross-platform.
+function toPosixPath(p: string) {
+	return p.split(path.sep).join('/')
+}
+
 async function copyUnignoredFiles(
 	srcDir: string,
 	destDir: string,
@@ -119,7 +127,10 @@ async function copyUnignoredFiles(
 			await fsExtra.copy(srcDir, destDir, {
 				filter: async (file) => {
 					if (file === srcDir) return true
-					return !ig.ignores(path.relative(srcDir, file))
+					// The `ignore` package only understands POSIX-style paths, so
+					// backslash-separated relative paths on Windows would silently
+					// fail to match patterns like `**/build/`.
+					return !ig.ignores(toPosixPath(path.relative(srcDir, file)))
 				},
 			})
 			return true
@@ -129,17 +140,14 @@ async function copyUnignoredFiles(
 
 async function prepareForDiff(app1: App, app2: App) {
 	const id = Math.random().toString(36).slice(2)
-	const app1CopyPath = path.join(
-		diffTmpDir,
-		path.basename(getWorkshopRoot()),
-		app1.name,
-		id,
+	// Paths are forced to POSIX form so that `git diff --no-index` does not
+	// quote them (git quotes any path containing a backslash, which then
+	// trips the patch parser downstream).
+	const app1CopyPath = toPosixPath(
+		path.join(diffTmpDir, path.basename(getWorkshopRoot()), app1.name, id),
 	)
-	const app2CopyPath = path.join(
-		diffTmpDir,
-		path.basename(getWorkshopRoot()),
-		app2.name,
-		id,
+	const app2CopyPath = toPosixPath(
+		path.join(diffTmpDir, path.basename(getWorkshopRoot()), app2.name, id),
 	)
 	// if everything except the `name` property of the `package.json` is the same
 	// the don't bother copying it
@@ -426,8 +434,11 @@ async function getDiffPatchImpl(app1: App, app2: App) {
 	void fsExtra.remove(app2CopyPath).catch(() => {})
 
 	const normalizedOutput = String(diffOutput ?? '')
-	const app1Relative = app1CopyPath.slice(1)
-	const app2Relative = app2CopyPath.slice(1)
+	// Strip a single leading `/` if present so the relative form is portable:
+	// `/tmp/foo` -> `tmp/foo` on POSIX, `C:/Users/foo` stays as-is on Windows.
+	// The original `.slice(1)` would have stripped the drive letter on Windows.
+	const app1Relative = app1CopyPath.replace(/^\//, '')
+	const app2Relative = app2CopyPath.replace(/^\//, '')
 
 	const testFiles = new Set([
 		...getAppTestFiles(app1),
@@ -436,10 +447,14 @@ async function getDiffPatchImpl(app1: App, app2: App) {
 
 	const filteredOutput = filterTestFilesFromPatch(
 		normalizedOutput
-			.replaceAll(`a${app1CopyPath}`, 'a')
-			.replaceAll(`b${app1CopyPath}`, 'b')
-			.replaceAll(`a${app2CopyPath}`, 'a')
-			.replaceAll(`b${app2CopyPath}`, 'b')
+			// Git always emits `a/<path>` / `b/<path>` (with the slash baked in).
+			// Constructing the search string as `a/${relative}` works on both
+			// POSIX (where `relative = tmp/foo` -> pattern `a/tmp/foo`) and Windows
+			// (where `relative = C:/Users/foo` -> pattern `a/C:/Users/foo`).
+			.replaceAll(`a/${app1Relative}`, 'a')
+			.replaceAll(`b/${app1Relative}`, 'b')
+			.replaceAll(`a/${app2Relative}`, 'a')
+			.replaceAll(`b/${app2Relative}`, 'b')
 			.replaceAll(`${app1CopyPath}/`, '')
 			.replaceAll(`${app2CopyPath}/`, '')
 			.replaceAll(`${app1Relative}/`, '')
@@ -473,7 +488,10 @@ export async function getDiffOutputWithRelativePaths(app1: App, app2: App) {
 	void fsExtra.remove(app1CopyPath).catch(() => {})
 	void fsExtra.remove(app2CopyPath).catch(() => {})
 
+	// Strip a single leading `/` if present so the relative form is portable
+	// across POSIX (`/tmp/foo` -> `tmp/foo`) and Windows (`C:/Users/foo` stays
+	// as-is; `.slice(1)` would have stripped the drive letter).
 	return diffOutput
-		.replaceAll(app1CopyPath.slice(1), '.')
-		.replaceAll(app2CopyPath.slice(1), '.')
+		.replaceAll(app1CopyPath.replace(/^\//, ''), '.')
+		.replaceAll(app2CopyPath.replace(/^\//, ''), '.')
 }


### PR DESCRIPTION
## What

Three small Windows path fixes in `packages/workshop-utils/src/diff.server.ts`.

## Why

On Windows, `path.join` and `path.relative` return backslash-separated paths. The diff pipeline assumed POSIX-style forward slashes in three places, so the **Diff** tab in any workshop crashes for Windows users with:

```
TypeError: Cannot read properties of undefined (reading 'trim')
    at processPatch (.../@pierre/diffs/.../parsePatchFiles.ts:90)
    at parsePatchFiles (.../parsePatchFiles.ts:297)
    at children (.../@epic-web/workshop-app/app/components/diff.tsx:368)
```

The root cause chain:

1. \`git diff --no-index\` quotes any path that contains a backslash. That quoted output trips \`@pierre/diffs\`'s patch parser, which only reads the unquoted capture groups of its filename regex and \`.trim()\`s an \`undefined\`.
2. \`copyUnignoredFiles\` passes the result of \`path.relative(...)\` directly to the \`ignore\` package. The \`ignore\` package only understands POSIX paths, so any gitignore pattern with a slash in it (\`**/build/\`, \`**/.react-router\`, etc.) silently fails to match.
3. \`.slice(1)\` was used to strip a leading slash from absolute paths. On POSIX (\`/tmp/foo\` → \`tmp/foo\`) this works; on Windows (\`C:/Users/foo\` → \`:/Users/foo\`) it strips the drive letter, breaking the subsequent \`replaceAll\` substitutions.

## Changes

1. **\`copyUnignoredFiles\`** — normalise \`path.relative(...)\` to POSIX before passing to \`ignore\`. Without this, gitignore patterns containing slashes silently fail to match on Windows.

2. **\`prepareForDiff\`** — normalise \`app1CopyPath\` / \`app2CopyPath\` to POSIX after \`path.join\`. Git now sees forward-slash paths and emits unquoted output, which the patch parser can handle.

3. **\`getDiffPatchImpl\` and \`getDiffOutputWithRelativePaths\`** — replace \`.slice(1)\` with \`.replace(/^\//, '')\` so Windows paths (no leading slash) keep their drive letter. The \`a\${absPath}\` patterns become \`a/\${relativePath}\` so they line up with the slash that git always inserts, on both platforms.

A small \`toPosixPath(p)\` helper is defined locally in the file; happy to extract it to a shared module if you'd prefer.

## Testing

- POSIX behaviour unchanged. The new \`a/\${relative}\` pattern produces the same search string as the old \`a\${absPath}\` form (since absPath always starts with \`/\` on POSIX, you'd get \`a/<rest>\` in both cases). The new \`replace(/^\//, '')\` produces the same result as the old \`.slice(1)\` whenever the input has exactly one leading slash.
- Windows: verified locally against a workshop with exercise paths under \`F:\projects\...\`. Before this PR the Diff tab crashes immediately; after, it renders.
- Workshop-utils typecheck passes.
- Existing test failures (\`data-storage.test.ts\` + a few others) are pre-existing Windows POSIX-path assumptions in unrelated modules, not introduced by this PR. Happy to file follow-ups for those.

## Notes

The downstream \`@pierre/diffs\` parser also has a latent bug — its \`diff --git\` line destructure only reads the unquoted capture groups, even though its own regex has a quoted-path branch. Fixing this PR is sufficient to make the diff tab work because git no longer emits quoted paths, but the parser fix is worth pursuing upstream as well.