### PR TITLE
Handle missing playground directory gracefully

### DIFF
--- a/packages/workshop-utils/src/apps-server.test.ts
+++ b/packages/workshop-utils/src/apps-server.test.ts
@@ -63,6 +63,32 @@ test('returns playground info when base app is missing', async () => {
 	expect(playgroundApp?.isUpToDate).toBe(false)
 }, 15000)
 
+test('does not return cached playground info after playground directory is removed', async () => {
+	await using workshop = await createTempWorkshop()
+
+	process.env.EPICSHOP_CONTEXT_CWD = workshop.root
+	;(
+		globalThis as { __epicshop_apps_initialized__?: boolean }
+	).__epicshop_apps_initialized__ = false
+	vi.resetModules()
+
+	const { getApps, getPlaygroundApp, setWorkshopRoot } =
+		await import('./apps.server.ts')
+	setWorkshopRoot(workshop.root)
+
+	await expect(getPlaygroundApp()).resolves.not.toBeNull()
+
+	await fs.rm(path.join(workshop.root, 'playground'), {
+		recursive: true,
+		force: true,
+	})
+
+	await expect(getPlaygroundApp()).resolves.toBeNull()
+	await expect(getApps()).resolves.not.toContainEqual(
+		expect.objectContaining({ name: 'playground' }),
+	)
+}, 15000)
+
 test('classifies non-index app without package.json as file dev type', async () => {
 	await using workshop = await createTempWorkshop()
 	const fileExtraDir = path.join(workshop.root, 'extra', '01.files')

--- a/packages/workshop-utils/src/apps.server.ts
+++ b/packages/workshop-utils/src/apps.server.ts
@@ -971,6 +971,7 @@ export async function getPlaygroundApp({
 	request,
 }: CachifiedOptions = {}): Promise<PlaygroundApp | null> {
 	const playgroundDir = path.join(getWorkshopRoot(), 'playground')
+	const playgroundDirExists = await exists(playgroundDir)
 	const baseAppName = await getPlaygroundAppName()
 	const baseAppFullPath = baseAppName
 		? await resolveExistingAppPath(baseAppName)
@@ -991,13 +992,15 @@ export async function getPlaygroundApp({
 		timings,
 		timingKey: playgroundDir.replace(`${playgroundDir}${path.sep}`, ''),
 		request,
-		forceFresh: await getForceFreshForDir(
-			playgroundCacheEntry,
-			playgroundDir,
-			baseAppFullPath,
-		),
+		forceFresh: playgroundDirExists
+			? await getForceFreshForDir(
+					playgroundCacheEntry,
+					playgroundDir,
+					baseAppFullPath,
+				)
+			: true,
 		getFreshValue: async () => {
-			if (!(await exists(playgroundDir))) return null
+			if (!playgroundDirExists) return null
 			if (!baseAppName) return null
 
 			const dirName = path.basename(playgroundDir)

--- a/packages/workshop-utils/src/apps.server.ts
+++ b/packages/workshop-utils/src/apps.server.ts
@@ -971,7 +971,8 @@ export async function getPlaygroundApp({
 	request,
 }: CachifiedOptions = {}): Promise<PlaygroundApp | null> {
 	const playgroundDir = path.join(getWorkshopRoot(), 'playground')
-	const playgroundDirExists = await exists(playgroundDir)
+	if (!(await exists(playgroundDir))) return null
+
 	const baseAppName = await getPlaygroundAppName()
 	const baseAppFullPath = baseAppName
 		? await resolveExistingAppPath(baseAppName)
@@ -992,15 +993,12 @@ export async function getPlaygroundApp({
 		timings,
 		timingKey: playgroundDir.replace(`${playgroundDir}${path.sep}`, ''),
 		request,
-		forceFresh: playgroundDirExists
-			? await getForceFreshForDir(
-					playgroundCacheEntry,
-					playgroundDir,
-					baseAppFullPath,
-				)
-			: true,
+		forceFresh: await getForceFreshForDir(
+			playgroundCacheEntry,
+			playgroundDir,
+			baseAppFullPath,
+		),
 		getFreshValue: async () => {
-			if (!playgroundDirExists) return null
 			if (!baseAppName) return null
 
 			const dirName = path.basename(playgroundDir)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Return `null` from `getPlaygroundApp()` before calling `cachified` when the `playground/` directory no longer exists.
- Add a regression test that caches playground metadata, removes `playground/`, and verifies the app list no longer exposes the stale playground app.

## Validation

- Precommit hook ran formatting, lint, typecheck, and build.
- Prepush hook ran the full Vitest suite.
- Focused `apps-server.test.ts` regression and full `npm run validate` pass.

## Context

Kody found the Sentry email for `EPICSHOP-G0`: `ENOENT: no such file or directory, scandir '/workspace/repo/playground'` from `GET *splat` at `http://localhost:5639/app/playground/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb86b487-2e5e-4440-a9b4-09b799475142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb86b487-2e5e-4440-a9b4-09b799475142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

