### PR TITLE
fix: wait for npm package availability before updating workshops

### DIFF
--- a/other/update-workshops/index.js
+++ b/other/update-workshops/index.js
@@ -117,13 +117,19 @@ async function verifyPackageAvailability(packageName, version, maxRetries = 30) 
 
 	for (let attempt = 1; attempt <= maxRetries; attempt++) {
 		try {
+			// Use AbortController for proper timeout handling
+			const controller = new AbortController()
+			const timeoutId = setTimeout(() => controller.abort(), 5000)
+
 			const response = await fetch(
 				`https://registry.npmjs.org/${packageName}/-/${tarballName}-${version}.tgz`,
 				{
 					method: 'HEAD',
-					timeout: 5000,
+					signal: controller.signal,
 				},
 			)
+			clearTimeout(timeoutId)
+
 			if (response.ok) {
 				console.log(
 					`✅ ${packageName}@${version} is available on npm registry`,
@@ -515,10 +521,19 @@ async function main() {
 		// before pushing updates to workshops to avoid 404 errors in workshop CI
 		console.log('\n🔐 Verifying package availability on npm registry...')
 		const epicshopAvailable = await verifyPackageAvailability('epicshop', version)
-		const workshopAppAvailable = await verifyPackageAvailability(
-			'@epic-web/workshop-app',
-			version,
-		)
+		
+		// If epicshop is not available, skip workshop-app check to avoid wasting time
+		let workshopAppAvailable = false
+		if (epicshopAvailable) {
+			workshopAppAvailable = await verifyPackageAvailability(
+				'@epic-web/workshop-app',
+				version,
+			)
+		} else {
+			console.log(
+				'⏭️  Skipping @epic-web/workshop-app verification since epicshop is unavailable',
+			)
+		}
 
 		if (!epicshopAvailable || !workshopAppAvailable) {
 			console.error(

--- a/other/update-workshops/index.js
+++ b/other/update-workshops/index.js
@@ -104,6 +104,57 @@ async function getLatestVersion() {
 	}
 }
 
+/**
+ * Verify that the epicshop package is available on npm registry
+ * This helps avoid 404 errors in workshop CI when npm registry replication is delayed
+ */
+async function verifyPackageAvailability(packageName, version, maxRetries = 30) {
+	const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+	for (let attempt = 1; attempt <= maxRetries; attempt++) {
+		try {
+			const response = await fetch(
+				`https://registry.npmjs.org/${packageName}/-/${packageName}-${version}.tgz`,
+				{
+					method: 'HEAD',
+					timeout: 5000,
+				},
+			)
+			if (response.ok) {
+				console.log(
+					`✅ ${packageName}@${version} is available on npm registry`,
+				)
+				return true
+			}
+			if (response.status !== 404) {
+				console.log(
+					`⚠️  Unexpected status ${response.status} when checking ${packageName}@${version}, retrying...`,
+				)
+			}
+		} catch (error) {
+			console.log(
+				`⚠️  Network error checking ${packageName}@${version}: ${error.message}`,
+			)
+		}
+
+		if (attempt < maxRetries) {
+			const waitSeconds = Math.min(2 ** (attempt - 1), 30)
+			console.log(
+				`⏳ Package not available yet (attempt ${attempt}/${maxRetries}). Waiting ${waitSeconds}s before retry...`,
+			)
+			await delay(waitSeconds * 1000)
+		}
+	}
+
+	console.warn(
+		`⚠️  ${packageName}@${version} was not available on npm after ${maxRetries} retries (${Math.ceil(maxRetries * 30 / 60)}+ minutes).`,
+	)
+	console.warn(
+		'This may cause workshop CI failures. Consider running the update again later.',
+	)
+	return false
+}
+
 async function pullRebaseWithFallback(cwd) {
 	try {
 		await execa('git', ['pull', '--rebase'], { cwd, env: getGitEnv() })
@@ -455,8 +506,26 @@ async function main() {
 		console.log('📦 Getting latest version from npm...')
 		const version = await getLatestVersion()
 		console.log(`🔍 Updating to version ${version}`)
+
+		// Verify that both epicshop and workshop-app are available on npm
+		// before pushing updates to workshops to avoid 404 errors in workshop CI
+		console.log('\n🔐 Verifying package availability on npm registry...')
+		const epicshopAvailable = await verifyPackageAvailability('epicshop', version)
+		const workshopAppAvailable = await verifyPackageAvailability(
+			'@epic-web/workshop-app',
+			version,
+		)
+
+		if (!epicshopAvailable || !workshopAppAvailable) {
+			console.error(
+				'\n❌ Required packages not available on npm. Aborting to prevent workshop CI failures.',
+			)
+			console.error('   Please try running this script again in a few minutes.')
+			process.exit(1)
+		}
+
 		console.log(
-			`🚀 Processing ${workshops.length} repos with concurrency ${CONCURRENCY}\n`,
+			`\n🚀 Processing ${workshops.length} repos with concurrency ${CONCURRENCY}\n`,
 		)
 
 		// Process repos in parallel with a simple concurrency pool (no extra deps)

--- a/other/update-workshops/index.js
+++ b/other/update-workshops/index.js
@@ -108,7 +108,7 @@ async function getLatestVersion() {
  * Verify that the epicshop package is available on npm registry
  * This helps avoid 404 errors in workshop CI when npm registry replication is delayed
  */
-async function verifyPackageAvailability(packageName, version, maxRetries = 10) {
+async function verifyPackageAvailability(packageName, version, maxRetries = 20) {
 	const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 	// For scoped packages like @epic-web/workshop-app, extract just the package name part
 	const tarballName = packageName.includes('/') 
@@ -121,10 +121,12 @@ async function verifyPackageAvailability(packageName, version, maxRetries = 10) 
 			const controller = new AbortController()
 			const timeoutId = setTimeout(() => controller.abort(), 5000)
 
+			// Use GET instead of HEAD to match what workshop CI does during install
+			// npm registry has had inconsistent HEAD responses for scoped packages
 			const response = await fetch(
 				`https://registry.npmjs.org/${packageName}/-/${tarballName}-${version}.tgz`,
 				{
-					method: 'HEAD',
+					method: 'GET',
 					signal: controller.signal,
 				},
 			)
@@ -156,8 +158,15 @@ async function verifyPackageAvailability(packageName, version, maxRetries = 10) 
 		}
 	}
 
+	// Calculate approximate wait time: sum of exponential backoff + fetch timeouts
+	const backoffSum = Array.from({ length: maxRetries - 1 }, (_, i) => 
+		Math.min(2 ** i, 30)
+	).reduce((a, b) => a + b, 0)
+	const totalSeconds = backoffSum + (maxRetries * 5)
+	const totalMinutes = Math.round(totalSeconds / 60)
+
 	console.warn(
-		`⚠️  ${packageName}@${version} was not available on npm after ${maxRetries} retries (~${Math.ceil(maxRetries * 2.5)} minutes).`,
+		`⚠️  ${packageName}@${version} was not available on npm after ${maxRetries} retries (~${totalMinutes} minute${totalMinutes !== 1 ? 's' : ''}).`,
 	)
 	console.warn(
 		'This may cause workshop CI failures. Consider running the update again later.',

--- a/other/update-workshops/index.js
+++ b/other/update-workshops/index.js
@@ -110,11 +110,15 @@ async function getLatestVersion() {
  */
 async function verifyPackageAvailability(packageName, version, maxRetries = 30) {
 	const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+	// For scoped packages like @epic-web/workshop-app, extract just the package name part
+	const tarballName = packageName.includes('/') 
+		? packageName.split('/')[1] 
+		: packageName
 
 	for (let attempt = 1; attempt <= maxRetries; attempt++) {
 		try {
 			const response = await fetch(
-				`https://registry.npmjs.org/${packageName}/-/${packageName}-${version}.tgz`,
+				`https://registry.npmjs.org/${packageName}/-/${tarballName}-${version}.tgz`,
 				{
 					method: 'HEAD',
 					timeout: 5000,

--- a/other/update-workshops/index.js
+++ b/other/update-workshops/index.js
@@ -108,7 +108,7 @@ async function getLatestVersion() {
  * Verify that the epicshop package is available on npm registry
  * This helps avoid 404 errors in workshop CI when npm registry replication is delayed
  */
-async function verifyPackageAvailability(packageName, version, maxRetries = 30) {
+async function verifyPackageAvailability(packageName, version, maxRetries = 10) {
 	const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 	// For scoped packages like @epic-web/workshop-app, extract just the package name part
 	const tarballName = packageName.includes('/') 
@@ -157,7 +157,7 @@ async function verifyPackageAvailability(packageName, version, maxRetries = 30) 
 	}
 
 	console.warn(
-		`⚠️  ${packageName}@${version} was not available on npm after ${maxRetries} retries (${Math.ceil(maxRetries * 30 / 60)}+ minutes).`,
+		`⚠️  ${packageName}@${version} was not available on npm after ${maxRetries} retries (~${Math.ceil(maxRetries * 2.5)} minutes).`,
 	)
 	console.warn(
 		'This may cause workshop CI failures. Consider running the update again later.',


### PR DESCRIPTION
## Problem
When the update-workshops workflow runs immediately after a new release, it pushes updates to workshop repos before the npm registry has fully replicated the newly published packages. This causes workshop CI failures with 404 errors when they try to download the new version.

## Root Cause
The npm registry has replication latency - it takes time for newly published packages to propagate across all CDN mirrors. When the update script pushes changes to 100+ workshop repos immediately after release, many of them encounter 404 errors when trying to download `epicshop@latest` in their CI jobs.

## Solution
Add a verification step that:
1. Waits for both `epicshop` and `@epic-web/workshop-app` to be available on npm before updating any workshops
2. Retries up to 30 times with exponential backoff (max 30s between attempts)
3. Aborts with a clear error message if packages aren't available after retries

This prevents pushing updates to workshops when the packages aren't fully available yet, avoiding cascading CI failures.

## Testing
The fix was developed after investigating the recent CI failures in react-fundamentals and other workshop repos. Once merged, future updates will check npm availability before proceeding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the release/update automation script’s preflight behavior; no runtime app, auth, or data paths are modified.
> 
> **Overview**
> The workshop bulk-update script now **blocks on npm registry readiness** before touching any repos, so pushes no longer land while `epicshop` and `@epic-web/workshop-app` tarballs are still missing (the usual cause of workshop CI 404s right after a release).
> 
> A new **`verifyPackageAvailability`** helper **GETs** the versioned tarball URL (aligned with how installs fetch, not HEAD), uses a **5s timeout** per attempt, and **retries with capped exponential backoff** (default **20** attempts). If **`epicshop`** never becomes available, **`@epic-web/workshop-app`** is not checked. If either check fails, the script **exits with an error** instead of updating workshops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346f39aca9aa6d1967560a307a2782302c404445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->