### PR TITLE
Fix Windows editor path parsing

### DIFF
--- a/packages/workshop-utils/src/launch-editor.server.test.ts
+++ b/packages/workshop-utils/src/launch-editor.server.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest'
+import { parseEditorCommand } from './launch-editor.server.ts'
+
+test('preserves unquoted Windows editor paths', () => {
+	const editor = String.raw`C:\Users\James\AppData\Local\Programs\cursor\Cursor.exe`
+
+	expect(parseEditorCommand(editor, 'win32')).toEqual([editor])
+})
+
+test('preserves unquoted Windows editor paths with arguments', () => {
+	const editor = String.raw`C:\Program Files\Microsoft VS Code\bin\code.cmd`
+
+	expect(parseEditorCommand(`${editor} --reuse-window`, 'win32')).toEqual([
+		editor,
+		'--reuse-window',
+	])
+})
+
+test('keeps shell parsing for non-Windows editor commands', () => {
+	expect(parseEditorCommand('code --reuse-window', 'linux')).toEqual([
+		'code',
+		'--reuse-window',
+	])
+})

--- a/packages/workshop-utils/src/launch-editor.server.ts
+++ b/packages/workshop-utils/src/launch-editor.server.ts
@@ -236,6 +236,29 @@ function getArgumentsForLineNumber(
 	return [fileName]
 }
 
+export function parseEditorCommand(
+	editor: string,
+	platform: NodeJS.Platform = process.platform,
+): Array<string | null> {
+	const trimmedEditor = editor.trim()
+	if (!trimmedEditor) return [null]
+
+	if (platform === 'win32') {
+		const windowsPathMatch = trimmedEditor.match(
+			/^((?:[A-Za-z]:|\\\\[^\\/]+[\\/][^\\/]+)[\\/].*?\.(?:exe|cmd|bat|com))(?:\s+(.*))?$/i,
+		)
+		if (windowsPathMatch) {
+			const [, command, args = ''] = windowsPathMatch
+			return [
+				command ?? null,
+				...shellQuote.parse(args).map((arg) => String(arg)),
+			]
+		}
+	}
+
+	return shellQuote.parse(trimmedEditor).map((arg) => String(arg))
+}
+
 function getWindowsProcessPaths(): string[] {
 	const systemRoot = process.env.SystemRoot ?? process.env.WINDIR
 	const wmicPath = systemRoot
@@ -272,7 +295,7 @@ function getWindowsProcessPaths(): string[] {
 function guessEditor(): Array<string | null> {
 	// Explicit config always wins
 	if (process.env.EPICSHOP_EDITOR) {
-		return shellQuote.parse(process.env.EPICSHOP_EDITOR).map((a) => String(a))
+		return parseEditorCommand(process.env.EPICSHOP_EDITOR)
 	}
 
 	// We can find out which editor is currently running by:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix `EPICSHOP_EDITOR` parsing so unquoted Windows absolute editor paths keep their backslashes.
- Add regression coverage for Windows Cursor/VS Code-style editor paths with and without arguments.

Fixes https://github.com/epicweb-dev/epicshop/issues/613

## Validation
- `npx vitest run packages/workshop-utils/src/launch-editor.server.test.ts --config packages/workshop-utils/vitest.config.ts`
- `npx nx run @epic-web/workshop-utils:build`
- `npx nx run @epic-web/workshop-utils:typecheck`
- `npm run lint -- --fix`
- `npm run format`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3409d954-5e46-4cbd-b113-fa287729e598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3409d954-5e46-4cbd-b113-fa287729e598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

