### PR TITLE
Fix TypeScript fixture execution on Node

### DIFF
--- a/other/update-workshops/index.js
+++ b/other/update-workshops/index.js
@@ -16,7 +16,7 @@ const GITHUB_TOKEN =
 const USING_WORKSHOP_UPDATE_TOKEN = Boolean(process.env.WORKSHOP_UPDATE_TOKEN)
 const CONCURRENCY = 5
 const TARGET_NODE_VERSION = '26.0.0'
-const ADDITIONAL_WORKSHOP_REPOS = ['workshop-template']
+const ADDITIONAL_WORKSHOP_REPOS = ['ai-powered-apps', 'workshop-template']
 
 if (!GITHUB_TOKEN) {
 	console.error(

--- a/other/update-workshops/index.js
+++ b/other/update-workshops/index.js
@@ -2,6 +2,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { execa } from 'execa'
+import semver from 'semver'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -14,7 +15,8 @@ const GITHUB_TOKEN =
 	process.env.WORKSHOP_UPDATE_TOKEN ?? process.env.GITHUB_TOKEN
 const USING_WORKSHOP_UPDATE_TOKEN = Boolean(process.env.WORKSHOP_UPDATE_TOKEN)
 const CONCURRENCY = 5
-const ADDITIONAL_WORKSHOP_REPOS = ['ai-powered-apps', 'workshop-template']
+const TARGET_NODE_VERSION = '26.0.0'
+const ADDITIONAL_WORKSHOP_REPOS = ['workshop-template']
 
 if (!GITHUB_TOKEN) {
 	console.error(
@@ -136,6 +138,42 @@ async function getLatestVersion() {
 		console.error('❌ Failed to get latest version:', error.message)
 		throw error
 	}
+}
+
+async function getPublishedWorkshopAppNodeRange(version) {
+	try {
+		const { stdout } = await execa('npm', [
+			'show',
+			`@epic-web/workshop-app@${version}`,
+			'engines.node',
+		])
+		return stdout.trim()
+	} catch (error) {
+		console.error(
+			`❌ Failed to get @epic-web/workshop-app@${version} node engine:`,
+			error.message,
+		)
+		throw error
+	}
+}
+
+async function verifyWorkshopAppSupportsTargetNode(version) {
+	const nodeRange = await getPublishedWorkshopAppNodeRange(version)
+	if (!nodeRange) {
+		throw new Error(
+			`@epic-web/workshop-app@${version} does not publish an engines.node range`,
+		)
+	}
+
+	if (!semver.satisfies(TARGET_NODE_VERSION, nodeRange)) {
+		throw new Error(
+			`@epic-web/workshop-app@${version} supports Node ${nodeRange}, not Node ${TARGET_NODE_VERSION}. Aborting before updating workshops.`,
+		)
+	}
+
+	console.log(
+		`✅ @epic-web/workshop-app@${version} supports Node ${TARGET_NODE_VERSION} (${nodeRange})`,
+	)
 }
 
 /**
@@ -562,6 +600,7 @@ async function main() {
 		console.log('📦 Getting latest version from npm...')
 		const version = await getLatestVersion()
 		console.log(`🔍 Updating to version ${version}`)
+		await verifyWorkshopAppSupportsTargetNode(version)
 
 		// Verify that both epicshop and workshop-app are available on npm
 		// before pushing updates to workshops to avoid 404 errors in workshop CI

--- a/other/update-workshops/package-lock.json
+++ b/other/update-workshops/package-lock.json
@@ -7,7 +7,8 @@
 			"name": "update-workshops",
 			"dependencies": {
 				"execa": "^9.6.1",
-				"globby": "^16.2.0"
+				"globby": "^16.2.0",
+				"semver": "^7.8.5"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -499,6 +500,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/signal-exit": {

--- a/other/update-workshops/package.json
+++ b/other/update-workshops/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "execa": "^9.6.1",
-    "globby": "^16.2.0"
+    "globby": "^16.2.0",
+    "semver": "^7.8.5"
   }
 }

--- a/packages/workshop-cli/src/commands/start.test.ts
+++ b/packages/workshop-cli/src/commands/start.test.ts
@@ -15,9 +15,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(__dirname, '..', '..', '..', '..')
 
 const testIf = process.platform === 'win32' ? test.skip : test
-const nodeMajorVersion = Number(process.versions.node.split('.')[0])
-const typeScriptRunnerArgs =
-	nodeMajorVersion >= 26 ? [] : ['--experimental-transform-types']
 
 testIf(
 	'start releases the child server port on shutdown',
@@ -25,20 +22,16 @@ testIf(
 		await using fixture = await createRunnerFixture()
 		let child: ChildProcess | null = null
 		try {
-			child = spawn(
-				process.execPath,
-				[...typeScriptRunnerArgs, fixture.runnerPath],
-				{
-					cwd: repoRoot,
-					env: {
-						...process.env,
-						EPICSHOP_APP_LOCATION: fixture.appDir,
-						EPICSHOP_CONTEXT_CWD: fixture.appDir,
-						NODE_ENV: 'development',
-					},
-					stdio: ['ignore', 'pipe', 'pipe'],
+			child = spawn(process.execPath, [fixture.runnerPath], {
+				cwd: repoRoot,
+				env: {
+					...process.env,
+					EPICSHOP_APP_LOCATION: fixture.appDir,
+					EPICSHOP_CONTEXT_CWD: fixture.appDir,
+					NODE_ENV: 'development',
 				},
-			)
+				stdio: ['ignore', 'pipe', 'pipe'],
+			})
 
 			if (!child) {
 				throw new Error('Failed to start runner process.')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Remove the obsolete `--experimental-transform-types` path from the workshop CLI start test so the TypeScript fixture runs directly with Node.
- Add a preflight to `other/update-workshops` that verifies the published `@epic-web/workshop-app` engine range supports the target Node runtime before updating workshops.
- Keep both `ai-powered-apps` and `workshop-template` in the explicit updater list so updates stay deterministic even while GitHub topic search indexing catches up.
- Directly standardized workshop `validate.yml` files on `main` across the workshop fleet with `workflow_dispatch`, job timeouts, and `SKIP_PLAYWRIGHT` on setup `epicshop add` steps.
- Tagged `epicweb-dev/ai-powered-apps` with the `workshop` topic and confirmed `workshop-template` remains untagged.

## AI review loop

- Behavioral review: no issues found.
- Code quality review: found one valid blocker that topic search had not indexed `ai-powered-apps`; addressed by restoring `ai-powered-apps` to the explicit updater list.
- Follow-up code quality review: no blocking issues.

## Testing

- `node --check other/update-workshops/index.js`
- `npm ci --ignore-scripts` in `other/update-workshops`
- `npm run format -- --check other/update-workshops/index.js other/update-workshops/package.json other/update-workshops/package-lock.json`
- `npm show @epic-web/workshop-app version` + semver check confirmed `@epic-web/workshop-app@6.90.9` supports Node 26 via `22 || 24 || 26`.
- `git commit` precommit hook ran format-staged, lint, typecheck, and build successfully.
- `git push` prepush hook ran `npm run test`: 24 files / 175 tests passed.
- PR CI is green for Build, Oxlint, TypeScript, Tests, Playwright, and Example on macOS/Ubuntu/Windows.
- Kody remote audit confirmed all 35 workshop workflows have `workflow_dispatch`, setup/deploy timeouts, and `SKIP_PLAYWRIGHT` on setup add-repo steps.
- Kody topic audit confirmed `ai-powered-apps` topics include `workshop`; `workshop-template` topics remain empty.
- GitHub Actions completed successfully for all 35 standardized workshop workflow runs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5db8343c-d49f-40be-b2f8-22a97ba461ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5db8343c-d49f-40be-b2f8-22a97ba461ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

