### PR TITLE
fix(ci): keep auto-format commits hook-free

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -36,7 +36,7 @@ jobs:
           cache: 'npm'
 
       - name: 📥 Download deps
-        run: npm ci --prefer-offline --no-audit --no-fund
+        run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
 
       - name: 🔧 Configure git
         run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -36,7 +36,7 @@ jobs:
           cache: 'npm'
 
       - name: 📥 Download deps
-        run: npm install --prefer-offline --no-audit --no-fund
+        run: npm ci --prefer-offline --no-audit --no-fund
 
       - name: 🔧 Configure git
         run: |
@@ -54,7 +54,7 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             git add .
             HUSKY=0 git commit -m "chore: cleanup 🧹"
-            git push
+            HUSKY=0 git push
             echo "Changes committed and pushed."
           else
             echo "No changes to commit."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Use `npm ci --ignore-scripts` in Auto Format so dependency installation does not run nested install scripts or rewrite lockfiles.
- Set `HUSKY=0` on the workflow-generated commit and push so local hooks do not run inside the bot cleanup path.

## Context

The first Auto Format fix let the bot commit pass precommit, but the subsequent push still triggered prepush tests. The same run also showed install-created lockfile churn. AI review found that plain `npm ci` still runs root `postinstall`, which invokes nested `npm install`, so the workflow now ignores install scripts.

## AI review loop

- Initial focused review found that `npm ci` still runs lifecycle scripts and could preserve nested install side effects.
- Addressed by changing Auto Format install to `npm ci --ignore-scripts --prefer-offline --no-audit --no-fund`.

## Testing

- Commit hooks ran format-staged, lint, typecheck, and build successfully.
- Push hooks ran `npm run test`: 24 files / 175 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5db8343c-d49f-40be-b2f8-22a97ba461ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5db8343c-d49f-40be-b2f8-22a97ba461ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

