### PR TITLE
fix(ci): install auto-format deps without lock writes

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -36,7 +36,9 @@ jobs:
           cache: 'npm'
 
       - name: 📥 Download deps
-        run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
+        run: >
+          npm install --ignore-scripts --package-lock=false --prefer-offline
+          --no-audit --no-fund
 
       - name: 🔧 Configure git
         run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Use `npm install --ignore-scripts --package-lock=false` in Auto Format so dependencies install without lifecycle scripts or lockfile writes.
- Keep `HUSKY=0` on the workflow-generated commit and push.

## Context

Plain `npm ci` cannot run on the current root lockfile because the root `vite` override intentionally differs from the lockfile. The Auto Format workflow needs the practical install behavior of `npm install` without nested install scripts or lockfile mutation.

## AI review loop

- Focused review found no blocking issues with the no-lock install approach.

## Testing

- Commit hooks ran format-staged, lint, typecheck, and build successfully.
- Push hooks ran `npm run test`: 24 files / 175 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5db8343c-d49f-40be-b2f8-22a97ba461ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5db8343c-d49f-40be-b2f8-22a97ba461ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

