### PR TITLE
Fix Windows editor path quoting

### DIFF
--- a/packages/workshop-utils/src/launch-editor.server.test.ts
+++ b/packages/workshop-utils/src/launch-editor.server.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest'
-import { parseEditorCommand } from './launch-editor.server.ts'
+import {
+	getWindowsEditorCommandArgs,
+	parseEditorCommand,
+} from './launch-editor.server.ts'
 
 test('preserves unquoted Windows editor paths', () => {
 	const editor = String.raw`C:\Users\James\AppData\Local\Programs\cursor\Cursor.exe`
@@ -20,5 +23,31 @@ test('keeps shell parsing for non-Windows editor commands', () => {
 	expect(parseEditorCommand('code --reuse-window', 'linux')).toEqual([
 		'code',
 		'--reuse-window',
+	])
+})
+
+test('quotes Windows editor command arguments with spaces (aha)', () => {
+	const editor = 'code'
+	const workshopPath = String.raw`C:\Users\Campbell L Mitchell\Campbell - Ensign College\epicshop-tutorial`
+
+	expect(getWindowsEditorCommandArgs(editor, [workshopPath])).toEqual([
+		'/D',
+		'/S',
+		'/C',
+		String.raw`"code" "C:\Users\Campbell L Mitchell\Campbell - Ensign College\epicshop-tutorial"`,
+	])
+})
+
+test('quotes Windows editor paths with spaces and preserves editor args', () => {
+	const editor = String.raw`C:\Program Files\Microsoft VS Code\bin\code.cmd`
+	const workshopPath = String.raw`C:\Users\Campbell L Mitchell\epicshop-tutorial`
+
+	expect(
+		getWindowsEditorCommandArgs(editor, ['--reuse-window', workshopPath]),
+	).toEqual([
+		'/D',
+		'/S',
+		'/C',
+		String.raw`"C:\Program Files\Microsoft VS Code\bin\code.cmd" "--reuse-window" "C:\Users\Campbell L Mitchell\epicshop-tutorial"`,
 	])
 })

--- a/packages/workshop-utils/src/launch-editor.server.ts
+++ b/packages/workshop-utils/src/launch-editor.server.ts
@@ -259,6 +259,22 @@ export function parseEditorCommand(
 	return shellQuote.parse(trimmedEditor).map((arg) => String(arg))
 }
 
+function quoteWindowsCmdArg(arg: string): string {
+	return `"${arg.replaceAll('"', '\\"')}"`
+}
+
+export function getWindowsEditorCommandArgs(
+	editor: string,
+	args: Array<string>,
+): Array<string> {
+	return [
+		'/D',
+		'/S',
+		'/C',
+		[quoteWindowsCmdArg(editor), ...args.map(quoteWindowsCmdArg)].join(' '),
+	]
+}
+
 function getWindowsProcessPaths(): string[] {
 	const systemRoot = process.env.SystemRoot ?? process.env.WINDIR
 	const wmicPath = systemRoot
@@ -604,7 +620,7 @@ export async function launchEditor(
 			// launch .exe files.
 			_childProcess = child_process.spawn(
 				'cmd.exe',
-				['/C', editor].concat(args).filter(Boolean),
+				getWindowsEditorCommandArgs(editor, args),
 				{ stdio: ['inherit', 'inherit', 'pipe'] },
 			)
 		} else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Quote Windows editor launch commands and workspace paths as one `cmd.exe` command line.
- Add regression coverage for editor/workshop paths containing spaces.

## Testing

- `npm exec vitest run packages/workshop-utils/src/launch-editor.server.test.ts`
- `npx nx run @epic-web/workshop-utils:typecheck`
- `npm run format:check -- packages/workshop-utils/src/launch-editor.server.ts packages/workshop-utils/src/launch-editor.server.test.ts`
- `npx nx run @epic-web/workshop-utils:build`
- `npm run lint`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1f2f-cc15-7614-acea-ed7ad64d0eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1f2f-cc15-7614-acea-ed7ad64d0eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

