### PR TITLE
Add ship-pr agent skill

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: ship-pr
+description: >
+  Babysit a PR. Iterate with AI reviewers and CI. Get it ready and maybe merge.
+  Send summary message.
+---
+
+# Ship PR
+
+## Loop
+
+1. Mark ready — `kody:@kentcdodds/github-pr-tools/set-pr-review-status` with
+   `{ prUrl, status: 'ready' }`, or `{ owner, repo, prNumber, status: 'ready' }`
+2. Wait for CI — `gh pr checks` (compose `loop-on-ci`, `fix-ci`)
+3. Fix failures; address valid AI-reviewer feedback (ignore insignificant nits /
+   already-fixed / wrong)
+4. Green and no valid feedback left → break
+5. Push → repeat
+
+## Mode
+
+By default, continue to Discord message with summary and include PR link
+
+If explicitly requested, merge PR as Kody with
+`kody:@kentcdodds/github-pr-tools/merge-pr` using
+`{ prUrl, mergeMethod: 'squash' }` (or `{ owner, repo, prNumber, ... }`;
+optional `commitTitle`), watch CI deploy, when finished, continue to the discord
+message and include a summary with link to PR, deployed URL link, or failing job
+link.
+
+Other useful exports on the same package: `get-pr-checks` for check-run status
+without `gh`, and `github-client` (`ghRestFetch` / `ghGraphQL`) for one-off
+authenticated GitHub calls.
+
+## Done → Discord
+
+```javascript
+import sendMeAMessage from 'kody:@kentcdodds/discord-gateway/send-me-a-message'
+
+export default async function main() {
+	const content = ` ... `
+	return sendMeAMessage({ content })
+}
+```


### PR DESCRIPTION
Copies the `ship-pr` Cursor/agent skill from `kentcdodds/kody` into this repo.

Path: `.agents/skills/ship-pr/SKILL.md`

This skill babysits a PR: mark ready, wait for CI, fix failures / valid AI review feedback, then Discord-summary (and optionally merge via Kody).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only agent skill with no runtime or application code changes.
> 
> **Overview**
> Adds a new agent skill at `.agents/skills/ship-pr/SKILL.md` (ported from `kentcdodds/kody`) so agents can **babysit a PR** through review and CI.
> 
> The skill defines a **repeat loop**: mark the PR ready via Kody `set-pr-review-status`, wait on CI (`gh pr checks` / related skills), fix failures and substantive AI review feedback, then push until checks are green. **Default exit** is a Discord summary with the PR link via `send-me-a-message`; optional mode merges as Kody with `merge-pr` (squash), watches deploy, then reports PR/deploy/failure links. It also points at `get-pr-checks` and `github-client` for GitHub automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d644c0427b014cec2c9cd6c130dc6c1a99164ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->