### PR TITLE
Make launch editor errors actionable with troubleshooting guidance

### DIFF
--- a/packages/workshop-app/app/components/toaster.tsx
+++ b/packages/workshop-app/app/components/toaster.tsx
@@ -5,7 +5,15 @@ import { type Toast } from '#app/utils/toast.server.ts'
 export function EpicToaster({ toast }: { toast?: Toast | null }) {
 	return (
 		<>
-			<Toaster closeButton position="top-center" />
+			<Toaster
+				closeButton
+				position="top-center"
+				toastOptions={{
+					classNames: {
+						description: 'whitespace-pre-line max-h-72 overflow-y-auto',
+					},
+				}}
+			/>
 			{toast ? <ShowToast toast={toast} /> : null}
 		</>
 	)
@@ -15,7 +23,12 @@ function ShowToast({ toast }: { toast: Toast }) {
 	const { id, type, title, description } = toast
 	useEffect(() => {
 		setTimeout(() => {
-			showToast[type](title, { id, description })
+			showToast[type](title, {
+				id,
+				description,
+				// give folks time to read (and act on) error messages
+				duration: type === 'error' ? Infinity : undefined,
+			})
 		}, 0)
 	}, [description, id, title, type])
 	return null

--- a/packages/workshop-app/app/components/toaster.tsx
+++ b/packages/workshop-app/app/components/toaster.tsx
@@ -9,9 +9,7 @@ export function EpicToaster({ toast }: { toast?: Toast | null }) {
 				closeButton
 				position="top-center"
 				toastOptions={{
-					classNames: {
-						description: 'whitespace-pre-line max-h-72 overflow-y-auto',
-					},
+					classNames: { description: 'whitespace-pre-line' },
 				}}
 			/>
 			{toast ? <ShowToast toast={toast} /> : null}
@@ -19,17 +17,50 @@ export function EpicToaster({ toast }: { toast?: Toast | null }) {
 	)
 }
 
+function ToastDescription({
+	description,
+	details,
+	onToggle,
+}: {
+	description: string
+	details?: string
+	onToggle?: () => void
+}) {
+	if (!details) return description
+	return (
+		<div>
+			<div className="whitespace-pre-line">{description}</div>
+			<details className="mt-2" onToggle={onToggle}>
+				<summary className="cursor-pointer font-medium">More details</summary>
+				<div className="mt-2 max-h-72 overflow-y-auto whitespace-pre-line">
+					{details}
+				</div>
+			</details>
+		</div>
+	)
+}
+
 function ShowToast({ toast }: { toast: Toast }) {
-	const { id, type, title, description } = toast
+	const { id, type, title, description, details } = toast
 	useEffect(() => {
-		setTimeout(() => {
+		function show() {
 			showToast[type](title, {
 				id,
-				description,
+				description: (
+					<ToastDescription
+						description={description}
+						details={details}
+						// re-issuing the toast changes the description element reference
+						// which makes sonner re-measure the toast height after the
+						// details element expands/collapses
+						onToggle={show}
+					/>
+				),
 				// give folks time to read (and act on) error messages
 				duration: type === 'error' ? Infinity : undefined,
 			})
-		}, 0)
-	}, [description, id, title, type])
+		}
+		setTimeout(show, 0)
+	}, [description, details, id, title, type])
 	return null
 }

--- a/packages/workshop-app/app/routes/launch-editor.tsx
+++ b/packages/workshop-app/app/routes/launch-editor.tsx
@@ -155,7 +155,8 @@ export async function action({ request }: Route.ActionArgs) {
 		return dataWithPE(request, formData, { status: 'success' } as const)
 	}
 	const results: Array<
-		{ status: 'success' } | { status: 'error'; message: string }
+		| { status: 'success' }
+		| { status: 'error'; message: string; details?: string }
 	> = []
 	for (const file of filesToOpen) {
 		results.push(await launchEditor(file.filepath, file.line, file.column))
@@ -164,17 +165,16 @@ export async function action({ request }: Route.ActionArgs) {
 	if (results.every((r) => r.status === 'success')) {
 		return dataWithPE(request, formData, { status: 'success' } as const)
 	} else {
-		const messages = results
+		const errors = results.filter((r) => r.status === 'error')
+		const messages = errors
 			.map((r, index, array) =>
-				r.status === 'error'
-					? array.length > 1
-						? `${index}. ${r.message}`
-						: r.message
-					: null,
+				array.length > 1 ? `${index}. ${r.message}` : r.message,
 			)
-			.filter(Boolean)
 			.join('\n')
-		console.error('Launch editor error:', messages)
+		const details = Array.from(
+			new Set(errors.map((r) => r.details).filter(Boolean)),
+		).join('\n\n')
+		console.error('Launch editor error:', messages, details)
 		return dataWithPE(
 			request,
 			formData,
@@ -184,6 +184,7 @@ export async function action({ request }: Route.ActionArgs) {
 					type: 'error',
 					title: 'Launch Editor Error',
 					description: messages,
+					details: details || undefined,
 				}),
 			},
 		)

--- a/packages/workshop-app/app/utils/toast.server.ts
+++ b/packages/workshop-app/app/utils/toast.server.ts
@@ -9,6 +9,8 @@ const TypeSchema = z.enum(['message', 'success', 'error'])
 const ToastSchema = z
 	.object({
 		description: z.string(),
+		// additional information rendered in an expandable "More details" section
+		details: z.string().optional(),
 		id: z.string().default(() => cuid()),
 		title: z.string().optional(),
 		type: TypeSchema.default('message'),
@@ -17,12 +19,14 @@ const ToastSchema = z
 		...toast,
 		title: toast.title ? sanitizeCookieValue(toast.title) : undefined,
 		description: sanitizeCookieValue(toast.description),
+		details: toast.details ? sanitizeCookieValue(toast.details) : undefined,
 	}))
 
 export type Toast = z.infer<typeof ToastSchema>
-export type OptionalToast = Omit<Toast, 'id' | 'type'> & {
+export type OptionalToast = Omit<Toast, 'id' | 'type' | 'details'> & {
 	id?: string
 	type?: z.infer<typeof TypeSchema>
+	details?: string
 }
 
 export const toastSessionStorage = createCookieSessionStorage({

--- a/packages/workshop-cli/src/commands/workshops.ts
+++ b/packages/workshop-cli/src/commands/workshops.ts
@@ -1804,7 +1804,7 @@ export async function openWorkshop(
 		if (result.status === 'error') {
 			return {
 				success: false,
-				message: result.message,
+				message: [result.message, result.details].filter(Boolean).join('\n\n'),
 			}
 		}
 

--- a/packages/workshop-utils/src/launch-editor.server.test.ts
+++ b/packages/workshop-utils/src/launch-editor.server.test.ts
@@ -85,9 +85,9 @@ test.skipIf(process.platform === 'win32')(
 		if (result.status !== 'error') throw new Error('expected an error result')
 		expect(result.message).toContain(`"${process.execPath}"`)
 		expect(result.message).toContain('exited with error code 1')
-		expect(result.message).toContain('editor exploded')
-		expect(result.message).toContain('EPICSHOP_EDITOR')
-		expect(result.message).toContain('/guide#file-links-troubleshooting')
+		expect(result.details).toContain('editor exploded')
+		expect(result.details).toContain('EPICSHOP_EDITOR')
+		expect(result.details).toContain('/guide#file-links-troubleshooting')
 	},
 )
 
@@ -102,8 +102,8 @@ test.skipIf(process.platform === 'win32')(
 		expect(result.message).toContain(
 			'The editor command "definitely-not-a-real-editor-command" was not found',
 		)
-		expect(result.message).toContain('EPICSHOP_EDITOR')
-		expect(result.message).toContain('/guide#file-links-troubleshooting')
+		expect(result.details).toContain('EPICSHOP_EDITOR')
+		expect(result.details).toContain('/guide#file-links-troubleshooting')
 	},
 )
 

--- a/packages/workshop-utils/src/launch-editor.server.test.ts
+++ b/packages/workshop-utils/src/launch-editor.server.test.ts
@@ -1,8 +1,36 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { expect, test } from 'vitest'
 import {
 	getWindowsEditorCommandArgs,
+	launchEditor,
 	parseEditorCommand,
 } from './launch-editor.server.ts'
+
+function withEditorEnv(editor: string) {
+	const original = process.env.EPICSHOP_EDITOR
+	process.env.EPICSHOP_EDITOR = editor
+	return {
+		[Symbol.dispose]() {
+			if (original === undefined) {
+				delete process.env.EPICSHOP_EDITOR
+			} else {
+				process.env.EPICSHOP_EDITOR = original
+			}
+		},
+	}
+}
+
+function createTempDir() {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'epicshop-launch-editor-'))
+	return {
+		dir,
+		[Symbol.dispose]() {
+			fs.rmSync(dir, { recursive: true, force: true })
+		},
+	}
+}
 
 test('preserves unquoted Windows editor paths', () => {
 	const editor = String.raw`C:\Users\James\AppData\Local\Programs\cursor\Cursor.exe`
@@ -37,6 +65,47 @@ test('quotes Windows editor command arguments with spaces (aha)', () => {
 		String.raw`"code" "C:\Users\Campbell L Mitchell\Campbell - Ensign College\epicshop-tutorial"`,
 	])
 })
+
+// These launch real child processes, which follows a different code path on
+// Windows (via cmd.exe). CI runs unit tests on Linux.
+test.skipIf(process.platform === 'win32')(
+	'includes the editor command, exit code, editor output, and config help when the editor fails (aha)',
+	async () => {
+		using temp = createTempDir()
+		const failingEditor = path.join(temp.dir, 'failing-editor.cjs')
+		fs.writeFileSync(
+			failingEditor,
+			"console.error('editor exploded')\nprocess.exit(1)\n",
+		)
+		using _env = withEditorEnv(`${process.execPath} ${failingEditor}`)
+
+		const resultPromise = launchEditor(path.join(temp.dir, 'index.js'))
+		await expect(resultPromise).resolves.toMatchObject({ status: 'error' })
+		const result = await resultPromise
+		if (result.status !== 'error') throw new Error('expected an error result')
+		expect(result.message).toContain(`"${process.execPath}"`)
+		expect(result.message).toContain('exited with error code 1')
+		expect(result.message).toContain('editor exploded')
+		expect(result.message).toContain('EPICSHOP_EDITOR')
+		expect(result.message).toContain('/guide#file-links-troubleshooting')
+	},
+)
+
+test.skipIf(process.platform === 'win32')(
+	'explains missing editor commands and how to configure EPICSHOP_EDITOR (aha)',
+	async () => {
+		using temp = createTempDir()
+		using _env = withEditorEnv('definitely-not-a-real-editor-command')
+
+		const result = await launchEditor(path.join(temp.dir, 'index.js'))
+		if (result.status !== 'error') throw new Error('expected an error result')
+		expect(result.message).toContain(
+			'The editor command "definitely-not-a-real-editor-command" was not found',
+		)
+		expect(result.message).toContain('EPICSHOP_EDITOR')
+		expect(result.message).toContain('/guide#file-links-troubleshooting')
+	},
+)
 
 test('quotes Windows editor paths with spaces and preserves editor args', () => {
 	const editor = String.raw`C:\Program Files\Microsoft VS Code\bin\code.cmd`

--- a/packages/workshop-utils/src/launch-editor.server.ts
+++ b/packages/workshop-utils/src/launch-editor.server.ts
@@ -484,6 +484,16 @@ let _childProcess: ReturnType<typeof child_process.spawn> | null = null
 export type Result =
 	| { status: 'success' }
 	| { status: 'error'; message: string }
+
+export const EDITOR_CONFIG_HELP = `To tell the workshop app which editor to use, create a ".env" file in the workshop root directory (the folder you run "npm start" in) with a line like this:
+
+EPICSHOP_EDITOR=code
+
+Replace "code" with the command for your editor (for example "cursor" for Cursor). If the command isn't on your PATH, use the full path to it and wrap it in quotes if it contains spaces, for example on Windows:
+
+EPICSHOP_EDITOR='"C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd"'
+
+Then restart the workshop app. For more help, see the "File Links" troubleshooting section in the app guide (click "?" at the bottom of the page or go to /guide#file-links-troubleshooting).`
 export async function launchEditor(
 	pathList: string[] | string,
 	lineNumber: number = 1,
@@ -507,7 +517,10 @@ export async function launchEditor(
 	let args = editorInfo.slice(1).filter(Boolean)
 
 	if (!editor) {
-		return { status: 'error', message: 'No editor found' }
+		return {
+			status: 'error',
+			message: `Could not determine which editor to open the file in.\n\n${EDITOR_CONFIG_HELP}`,
+		}
 	}
 
 	if (editor.toLowerCase() === 'none') {
@@ -628,11 +641,14 @@ export async function launchEditor(
 				stdio: ['inherit', 'inherit', 'pipe'],
 			})
 		}
+		let editorStderr = ''
 		_childProcess.stderr?.on('data', (data: string | Uint8Array) => {
 			const message = String(data)
 			// Filter out the specific error message for environment variable issues
 			if (!message.includes('Node.js environment variables are disabled')) {
 				process.stderr.write(data) // Only write non-filtered messages to stderr
+				// keep the tail of the output for the error message shown to the user
+				editorStderr = `${editorStderr}${message}`.slice(-1000)
 			}
 		})
 		_childProcess.on('exit', async (errorCode) => {
@@ -641,9 +657,18 @@ export async function launchEditor(
 			if (errorCode) {
 				const readableName =
 					fileList.length === 1 ? readablePath(fileList[0]) : 'some files'
+				const editorOutput = editorStderr.trim()
 				return res({
 					status: 'error',
-					message: `Could not open ${readableName} in the editor.\n\nThe editor process exited with an error code (${errorCode}).`,
+					message: [
+						`Could not open ${readableName} in the editor.`,
+						`The editor command "${editor}" exited with error code ${errorCode}.`,
+						editorOutput ? `Editor output:\n${editorOutput}` : null,
+						`This usually means the editor command is misconfigured or not installed.`,
+						EDITOR_CONFIG_HELP,
+					]
+						.filter(Boolean)
+						.join('\n\n'),
 				})
 			} else if (errorsList.length) {
 				// show error message even when the editor was opened successfully,
@@ -662,7 +687,16 @@ export async function launchEditor(
 						'Unable to launch editor. This commonly happens when running in a containerized or server environment without terminal access.',
 				})
 			}
-			return res({ status: 'error', message: error.message })
+			if (error.code === 'ENOENT') {
+				return res({
+					status: 'error',
+					message: `The editor command "${editor}" was not found. Make sure your editor is installed and its command is available on your PATH.\n\n${EDITOR_CONFIG_HELP}`,
+				})
+			}
+			return res({
+				status: 'error',
+				message: `Failed to launch the editor command "${editor}": ${error.message}\n\n${EDITOR_CONFIG_HELP}`,
+			})
 		})
 	})
 }

--- a/packages/workshop-utils/src/launch-editor.server.ts
+++ b/packages/workshop-utils/src/launch-editor.server.ts
@@ -483,7 +483,7 @@ export function getDefaultEditorCommand(): string | null {
 let _childProcess: ReturnType<typeof child_process.spawn> | null = null
 export type Result =
 	| { status: 'success' }
-	| { status: 'error'; message: string }
+	| { status: 'error'; message: string; details?: string }
 
 export const EDITOR_CONFIG_HELP = `To tell the workshop app which editor to use, create a ".env" file in the workshop root directory (the folder you run "npm start" in) with a line like this:
 
@@ -519,7 +519,8 @@ export async function launchEditor(
 	if (!editor) {
 		return {
 			status: 'error',
-			message: `Could not determine which editor to open the file in.\n\n${EDITOR_CONFIG_HELP}`,
+			message: 'Could not determine which editor to open the file in.',
+			details: EDITOR_CONFIG_HELP,
 		}
 	}
 
@@ -660,11 +661,9 @@ export async function launchEditor(
 				const editorOutput = editorStderr.trim()
 				return res({
 					status: 'error',
-					message: [
-						`Could not open ${readableName} in the editor.`,
-						`The editor command "${editor}" exited with error code ${errorCode}.`,
+					message: `Could not open ${readableName} in the editor.\n\nThe editor command "${editor}" exited with error code ${errorCode}. This usually means the editor command is misconfigured or not installed.`,
+					details: [
 						editorOutput ? `Editor output:\n${editorOutput}` : null,
-						`This usually means the editor command is misconfigured or not installed.`,
 						EDITOR_CONFIG_HELP,
 					]
 						.filter(Boolean)
@@ -690,12 +689,14 @@ export async function launchEditor(
 			if (error.code === 'ENOENT') {
 				return res({
 					status: 'error',
-					message: `The editor command "${editor}" was not found. Make sure your editor is installed and its command is available on your PATH.\n\n${EDITOR_CONFIG_HELP}`,
+					message: `The editor command "${editor}" was not found. Make sure your editor is installed and its command is available on your PATH.`,
+					details: EDITOR_CONFIG_HELP,
 				})
 			}
 			return res({
 				status: 'error',
-				message: `Failed to launch the editor command "${editor}": ${error.message}\n\n${EDITOR_CONFIG_HELP}`,
+				message: `Failed to launch the editor command "${editor}": ${error.message}`,
+				details: EDITOR_CONFIG_HELP,
 			})
 		})
 	})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

A workshop user on Windows reported (via email) hitting this error when clicking a file link in the workshop app:

> Could not open 'index.js' from: 'playground' in the editor. The editor process exited with an error code (1).

That message gives the user (and us) nothing to act on: it doesn't say which editor command was attempted, what the editor printed, or how to fix it.

## Changes

- `launch-editor.server.ts` now captures the editor process's stderr output, and its error results separate a concise `message` (which editor command failed and how) from optional `details` (the editor's output plus configuration guidance).
- All editor launch failures (exit code, command not found/ENOENT, no editor detected, other spawn errors) include configuration guidance in `details`: set `EPICSHOP_EDITOR` in a `.env` file at the workshop root (with a quoting example for Windows paths with spaces) and a pointer to the guide's File Links troubleshooting section (`/guide#file-links-troubleshooting`).
- Toasts support an optional `details` field rendered as a collapsed "More details" `<details>` expander below the concise description, so the toast stays compact until the user opts into the full troubleshooting help. Toggling re-issues the toast so sonner re-measures the card height.
- Toast descriptions render line breaks, and error toasts stay open until dismissed so users have time to read and act on them.
- The CLI's `openWorkshop` joins message and details for terminal output.
- Added tests covering the failing-editor and missing-editor-command error results.

## Demo

<a href="https://cursor.com/agents/bc-02398434-df30-4316-a32a-6544a69aaa46/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flaunch_editor_error_more_details_final_demo.mp4"><img src="https://cursor.com/artifacts/c/art-1f21524c-37b2-4c68-9b1e-be17d763e4fb" alt="launch_editor_error_more_details_final_demo.mp4" /></a>

Reproduced with `EPICSHOP_EDITOR` pointing at a script that mimics the Windows "'code' is not recognized" failure (prints to stderr, exits 1).

![Compact error toast with collapsed More details expander](https://cursor.com/artifacts/c/art-074060b3-245e-46de-8e1a-128c89c59d49)
![Toast expanded to show editor output and EPICSHOP_EDITOR configuration help](https://cursor.com/artifacts/c/art-c97e1f94-0712-4272-9302-9a91e7a3b6f8)

## Testing

- `npm run test` (179 tests pass, including 2 new launch-editor error message tests)
- `nx run-many --target typecheck,lint` for `@epic-web/workshop-utils`, `@epic-web/workshop-app`, and `epicshop`
- Manual GUI test against the example workshop with a failing editor configured (video above)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02398434-df30-4316-a32a-6544a69aaa46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02398434-df30-4316-a32a-6544a69aaa46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

