### PR TITLE
chore(update-workshops): skip gitignored files when staging

### DIFF
--- a/other/update-workshops/index.js
+++ b/other/update-workshops/index.js
@@ -506,10 +506,29 @@ async function updateWorkshopRepo(repo, version) {
 			}
 		}
 
+		// Some workshop repos gitignore files we'd otherwise stage (e.g.
+		// epicshop/package-lock.json) and `git add` fails on ignored files.
+		const stageableFiles = []
+		for (const file of filesToStage) {
+			// check-ignore exits 0 when the file is ignored and 1 when it's not
+			const { exitCode } = await execa('git', ['check-ignore', '-q', file], {
+				cwd: tempDir,
+				env: getGitEnv(),
+				reject: false,
+			})
+			if (exitCode === 0) {
+				console.log(`🙈 ${repoName} - skipping gitignored file: ${file}`)
+			} else {
+				stageableFiles.push(file)
+			}
+		}
+
 		// Stage changes
-		console.log(`📝 ${repoName} - staging changes: ${filesToStage.join(', ')}`)
-		if (filesToStage.length > 0) {
-			await execa('git', ['add', ...filesToStage], {
+		console.log(
+			`📝 ${repoName} - staging changes: ${stageableFiles.join(', ')}`,
+		)
+		if (stageableFiles.length > 0) {
+			await execa('git', ['add', ...stageableFiles], {
 				cwd: tempDir,
 				env: getGitEnv(),
 			})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

The Update Workshops workflow run [29281433533](https://github.com/epicweb-dev/epicshop/actions/runs/29281433533) updated 33 of 34 repos but failed on `ai-powered-apps`:

```
❌ ai-powered-apps - failed: Command failed with exit code 1: git add package.json epicshop/package.json epicshop/package-lock.json
The following paths are ignored by one of your .gitignore files:
epicshop/package-lock.json
```

That repo gitignores `epicshop/package-lock.json`, and `git add` refuses to stage ignored files, which fails the whole run.

## Changes

- `other/update-workshops/index.js` filters the files to stage through `git check-ignore` first and logs any skipped gitignored file, so repos that ignore their lock file update cleanly.

## Testing

- Replicated the filtering logic in a scratch git repo with a gitignored `epicshop/package-lock.json`: the ignored file is skipped, the other files stage successfully, and `git add` no longer errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02398434-df30-4316-a32a-6544a69aaa46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02398434-df30-4316-a32a-6544a69aaa46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

