### PR TITLE
Fix Windows editor command quoting

### DIFF
--- a/packages/workshop-utils/src/launch-editor.server.test.ts
+++ b/packages/workshop-utils/src/launch-editor.server.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { expect, test } from 'vitest'
 import {
+	getWindowsEditorCommand,
 	getWindowsEditorCommandArgs,
 	launchEditor,
 	parseEditorCommand,
@@ -62,7 +63,7 @@ test('quotes Windows editor command arguments with spaces (aha)', () => {
 		'/D',
 		'/S',
 		'/C',
-		String.raw`"code" "C:\Users\Campbell L Mitchell\Campbell - Ensign College\epicshop-tutorial"`,
+		String.raw`""code" "C:\Users\Campbell L Mitchell\Campbell - Ensign College\epicshop-tutorial""`,
 	])
 })
 
@@ -117,6 +118,22 @@ test('quotes Windows editor paths with spaces and preserves editor args', () => 
 		'/D',
 		'/S',
 		'/C',
-		String.raw`"C:\Program Files\Microsoft VS Code\bin\code.cmd" "--reuse-window" "C:\Users\Campbell L Mitchell\epicshop-tutorial"`,
+		String.raw`""C:\Program Files\Microsoft VS Code\bin\code.cmd" "--reuse-window" "C:\Users\Campbell L Mitchell\epicshop-tutorial""`,
 	])
+})
+
+test('passes the wrapped command to cmd without Node rewriting its quotes (aha)', () => {
+	const editor = String.raw`C:\Users\Ada\AppData\Local\Programs\Microsoft VS Code\Code.exe`
+	const fileName = String.raw`C:\Users\Ada\Epic Workshop\index.ts`
+
+	expect(getWindowsEditorCommand(editor, ['-g', `${fileName}:1:1`])).toEqual({
+		file: 'cmd.exe',
+		args: [
+			'/D',
+			'/S',
+			'/C',
+			String.raw`""C:\Users\Ada\AppData\Local\Programs\Microsoft VS Code\Code.exe" "-g" "C:\Users\Ada\Epic Workshop\index.ts:1:1""`,
+		],
+		options: { windowsVerbatimArguments: true },
+	})
 })

--- a/packages/workshop-utils/src/launch-editor.server.ts
+++ b/packages/workshop-utils/src/launch-editor.server.ts
@@ -267,12 +267,22 @@ export function getWindowsEditorCommandArgs(
 	editor: string,
 	args: Array<string>,
 ): Array<string> {
-	return [
-		'/D',
-		'/S',
-		'/C',
-		[quoteWindowsCmdArg(editor), ...args.map(quoteWindowsCmdArg)].join(' '),
-	]
+	const command = [
+		quoteWindowsCmdArg(editor),
+		...args.map(quoteWindowsCmdArg),
+	].join(' ')
+	// /S strips the first and last quotes, so add an outer pair around the
+	// individually quoted command and arguments.
+	return ['/D', '/S', '/C', `"${command}"`]
+}
+
+export function getWindowsEditorCommand(editor: string, args: Array<string>) {
+	return {
+		file: 'cmd.exe',
+		args: getWindowsEditorCommandArgs(editor, args),
+		// cmd.exe parses quotes itself and does not understand libuv's \" escapes.
+		options: { windowsVerbatimArguments: true },
+	}
 }
 
 function getWindowsProcessPaths(): string[] {
@@ -632,10 +642,14 @@ export async function launchEditor(
 		if (process.platform === 'win32') {
 			// On Windows, launch the editor in a shell because spawn can only
 			// launch .exe files.
+			const windowsCommand = getWindowsEditorCommand(editor, args)
 			_childProcess = child_process.spawn(
-				'cmd.exe',
-				getWindowsEditorCommandArgs(editor, args),
-				{ stdio: ['inherit', 'inherit', 'pipe'] },
+				windowsCommand.file,
+				windowsCommand.args,
+				{
+					stdio: ['inherit', 'inherit', 'pipe'],
+					...windowsCommand.options,
+				},
 			)
 		} else {
 			_childProcess = child_process.spawn(editor, args, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

A workshop user confirmed the issue persists on the latest release. The improved error details show that `cmd.exe` cannot recognize the detected full VS Code executable path when it contains spaces.

## Root cause

The previous fix quoted each command token, but `cmd.exe /S /C` strips the first and last quote characters. Node/libuv also rewrites embedded quotes unless Windows arguments are passed verbatim. Together, those behaviors remove the quoting around the spaced executable path before `cmd.exe` evaluates it.

## Changes

- Wrap the complete Windows editor command in the extra quote pair required by `cmd.exe /S /C`.
- Set `windowsVerbatimArguments` so Node/libuv does not rewrite the quotes before `cmd.exe` parses them.
- Add regression coverage for full editor and workshop paths containing spaces.

## Testing

- Native Windows Node 24.16 under Wine: previous command exits `9009` with “not recognized”; fixed command exits `0` and launches the spaced executable path.
- `npx vitest run packages/workshop-utils/src/launch-editor.server.test.ts` — 8 tests pass.
- `npm run format:check -- packages/workshop-utils/src/launch-editor.server.ts packages/workshop-utils/src/launch-editor.server.test.ts` — passes.
- `npm run validate` — all build, typecheck, lint, and test targets pass (five pre-existing lint warnings).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a4f75d2-2c04-4553-a472-4f2e653c1aee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a4f75d2-2c04-4553-a472-4f2e653c1aee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

