### PR TITLE
fix: drop expected MCP workshop-directory errors from Sentry

### DIFF
--- a/packages/workshop-mcp/src/index.ts
+++ b/packages/workshop-mcp/src/index.ts
@@ -6,6 +6,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import * as Sentry from '@sentry/node'
 import { initPrompts } from './prompts.ts'
 import { initResources } from './resources.ts'
+import { isExpectedMcpSentryNoise } from './sentry-filters.ts'
 import { serverInstructions } from './server-metadata.ts'
 import { initPromptTools, initResourceTools, initTools } from './tools.ts'
 
@@ -23,6 +24,11 @@ if (shouldEnableSentry) {
 		sendDefaultPii: true,
 		environment: env.EPICSHOP_IS_PUBLISHED ? 'production' : 'development',
 		tracesSampleRate: 1.0,
+		beforeSend(event, hint) {
+			// Expected agent/user mistakes (wrong cwd, missing workshop root, etc.)
+			if (isExpectedMcpSentryNoise(event, hint)) return null
+			return event
+		},
 	})
 }
 

--- a/packages/workshop-mcp/src/sentry-filters.test.ts
+++ b/packages/workshop-mcp/src/sentry-filters.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from 'vitest'
+import {
+	ExpectedMcpError,
+	isExpectedMcpErrorMessage,
+	isExpectedMcpSentryNoise,
+} from './sentry-filters.ts'
+
+test('ExpectedMcpError uses a stable name for Sentry typing (aha)', () => {
+	const error = new ExpectedMcpError('The workshop directory is required')
+	expect(error.name).toBe('ExpectedMcpError')
+	expect(error).toBeInstanceOf(Error)
+})
+
+test('matches no-workshop-directory messages', () => {
+	expect(
+		isExpectedMcpErrorMessage(
+			'No workshop directory found while searching upward from "/tmp/foo" to filesystem root "/"',
+		),
+	).toBe(true)
+})
+
+test('matches required workshop directory messages', () => {
+	expect(isExpectedMcpErrorMessage('The workshop directory is required')).toBe(
+		true,
+	)
+})
+
+test('does not match unrelated errors', () => {
+	expect(isExpectedMcpErrorMessage('Cannot find package zod')).toBe(false)
+})
+
+test('drops ExpectedMcpError via originalException hint', () => {
+	expect(
+		isExpectedMcpSentryNoise(
+			{ exception: { values: [] } },
+			{
+				originalException: new ExpectedMcpError(
+					'The workshop directory is required',
+				),
+			},
+		),
+	).toBe(true)
+})
+
+test('drops ExpectedMcpError exception type from event payload', () => {
+	expect(
+		isExpectedMcpSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'ExpectedMcpError',
+						value: 'The workshop directory is required',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('drops JsonRpcError events that wrap expected workshop messages (aha)', () => {
+	expect(
+		isExpectedMcpSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'JsonRpcError_-32603',
+						value:
+							'No workshop directory found while searching upward from "/Users/hirotaka/Workspaces/github.com/hirotaka/pragmatic-nuxt/$1" to filesystem root "/"',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('keeps unrelated JsonRpcError events', () => {
+	expect(
+		isExpectedMcpSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'JsonRpcError_-32603',
+						value: 'Unexpected internal failure in get_diff',
+					},
+				],
+			},
+		}),
+	).toBe(false)
+})

--- a/packages/workshop-mcp/src/sentry-filters.ts
+++ b/packages/workshop-mcp/src/sentry-filters.ts
@@ -1,0 +1,49 @@
+/**
+ * Expected client/agent mistakes (wrong cwd, missing workshop root, etc.).
+ * These are useful as MCP error responses, but not as Sentry issues.
+ */
+export class ExpectedMcpError extends Error {
+	override name = 'ExpectedMcpError'
+}
+
+const expectedMcpErrorMessagePatterns = [
+	/^No workshop directory found while searching upward from /,
+	/^The workshop directory is required$/,
+]
+
+type SentryExceptionValue = {
+	type?: string
+	value?: string
+}
+
+type SentryEventWithException = {
+	exception?: {
+		values?: Array<SentryExceptionValue>
+	}
+}
+
+export function isExpectedMcpErrorMessage(message: string) {
+	return expectedMcpErrorMessagePatterns.some((pattern) =>
+		pattern.test(message),
+	)
+}
+
+export function isExpectedMcpSentryNoise(
+	event: SentryEventWithException,
+	hint?: { originalException?: unknown },
+) {
+	if (hint?.originalException instanceof ExpectedMcpError) return true
+
+	return (
+		event.exception?.values?.some((value) => {
+			if (value.type === 'ExpectedMcpError') return true
+			if (
+				typeof value.value === 'string' &&
+				isExpectedMcpErrorMessage(value.value)
+			) {
+				return true
+			}
+			return false
+		}) ?? false
+	)
+}

--- a/packages/workshop-mcp/src/utils.test.ts
+++ b/packages/workshop-mcp/src/utils.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { test, expect, vi } from 'vitest'
+import { ExpectedMcpError } from './sentry-filters.ts'
 import {
 	handleWorkshopDirectory,
 	workshopDirectoryInputSchema,
@@ -109,6 +110,9 @@ test('handleWorkshopDirectory rejects blank input (aha)', async () => {
 	await expect(handleWorkshopDirectory('   ')).rejects.toThrow(
 		'The workshop directory is required',
 	)
+	await expect(handleWorkshopDirectory('   ')).rejects.toBeInstanceOf(
+		ExpectedMcpError,
+	)
 })
 
 test('handleWorkshopDirectory resolves relative paths from cwd (aha)', async () => {
@@ -158,4 +162,7 @@ test('handleWorkshopDirectory rejects when no workshop directory found (aha)', a
 	await expect(handleWorkshopDirectory(searchStartDirectory)).rejects.toThrow(
 		`No workshop directory found while searching upward from "${searchStartDirectory}" to filesystem root "${filesystemRoot}"`,
 	)
+	await expect(
+		handleWorkshopDirectory(searchStartDirectory),
+	).rejects.toBeInstanceOf(ExpectedMcpError)
 })

--- a/packages/workshop-mcp/src/utils.ts
+++ b/packages/workshop-mcp/src/utils.ts
@@ -5,6 +5,7 @@ import {
 	init as initApps,
 } from '@epic-web/workshop-utils/apps.server'
 import { z } from 'zod/v3'
+import { ExpectedMcpError } from './sentry-filters.ts'
 
 export const workshopDirectoryInputSchema = z
 	.string()
@@ -38,7 +39,9 @@ async function isWorkshopDirectory(workshopDirectory: string) {
 export async function handleWorkshopDirectory(workshopDirectory: string) {
 	workshopDirectory = workshopDirectory.trim()
 
-	if (!workshopDirectory) throw new Error('The workshop directory is required')
+	if (!workshopDirectory) {
+		throw new ExpectedMcpError('The workshop directory is required')
+	}
 
 	if (!path.isAbsolute(workshopDirectory)) {
 		workshopDirectory = path.resolve(process.cwd(), workshopDirectory)
@@ -53,7 +56,7 @@ export async function handleWorkshopDirectory(workshopDirectory: string) {
 	while (true) {
 		if (await isWorkshopDirectory(workshopDirectory)) break
 		if (workshopDirectory === path.dirname(workshopDirectory)) {
-			throw new Error(
+			throw new ExpectedMcpError(
 				`No workshop directory found while searching upward from "${searchStartDirectory}" to filesystem root "${workshopDirectory}"`,
 			)
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Agents invoking `@epic-web/workshop-mcp` outside a workshop root were flooding Sentry with `No workshop directory found...` noise (e.g. from non-workshop repos like pragmatic-nuxt).

This treats those as expected client/agent mistakes:
- throw `ExpectedMcpError` when the workshop directory is missing/invalid
- filter them in MCP `Sentry.beforeSend`, including JsonRpcError wraps from `wrapMcpServerWithSentry`

## Test plan
- [x] `nx run @epic-web/workshop-mcp:test`
- [x] Unit coverage for filter helpers and `ExpectedMcpError` throw paths

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09100140-7a3b-4f20-ad81-1b200f8040b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09100140-7a3b-4f20-ad81-1b200f8040b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

