### PR TITLE
fix: reject unexpanded shell vars in MCP args

### DIFF
--- a/packages/workshop-mcp/README.md
+++ b/packages/workshop-mcp/README.md
@@ -36,6 +36,9 @@ Add a server entry (shape varies slightly by client):
 - The server communicates over **stdio**.
 - If you’re using this inside a workshop repo, run your editor/assistant with
   the workshop as the working directory so the server can find the right files.
+- Do not put unexpanded shell placeholders (like `$1` / `$2`) in MCP `args` or
+  tool arguments. Clients that leave those literal will fail validation with a
+  configuration guidance error.
 
 ## Documentation
 

--- a/packages/workshop-mcp/src/mcp-arg-validation.test.ts
+++ b/packages/workshop-mcp/src/mcp-arg-validation.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'vitest'
+import {
+	assertNoUnexpandedShellVariable,
+	findUnexpandedShellVariable,
+} from './mcp-arg-validation.ts'
+import { ExpectedMcpError } from './sentry-filters.ts'
+
+test('detects positional shell placeholders as whole values (aha)', () => {
+	expect(findUnexpandedShellVariable('$1')).toBe('$1')
+	expect(findUnexpandedShellVariable('$2')).toBe('$2')
+	expect(findUnexpandedShellVariable('${1}')).toBe('${1}')
+})
+
+test('detects unexpanded shell placeholders in path segments (aha)', () => {
+	expect(
+		findUnexpandedShellVariable('/home/sekou/Dev/ia-vocal-note-app/$1'),
+	).toBe('$1')
+	expect(
+		findUnexpandedShellVariable('/Users/hirotaka/Workspaces/pragmatic-nuxt/$1'),
+	).toBe('$1')
+	expect(findUnexpandedShellVariable('C:\\workshops\\$WORKSHOP_DIR')).toBe(
+		'$WORKSHOP_DIR',
+	)
+})
+
+test('does not flag ordinary paths that happen to include a dollar sign later', () => {
+	expect(findUnexpandedShellVariable('/home/user/workshop')).toBeNull()
+	expect(findUnexpandedShellVariable('/tmp/price$tag-workshop')).toBeNull()
+	expect(findUnexpandedShellVariable('4')).toBeNull()
+})
+
+test('assertNoUnexpandedShellVariable throws ExpectedMcpError with guidance (aha)', () => {
+	expect(() =>
+		assertNoUnexpandedShellVariable(
+			'workshopDirectory',
+			'/home/sekou/Dev/ia-vocal-note-app/$1',
+		),
+	).toThrow(ExpectedMcpError)
+	expect(() =>
+		assertNoUnexpandedShellVariable(
+			'workshopDirectory',
+			'/home/sekou/Dev/ia-vocal-note-app/$1',
+		),
+	).toThrow(/unexpanded shell variable.*"\$1"/i)
+	expect(() =>
+		assertNoUnexpandedShellVariable(
+			'workshopDirectory',
+			'/home/sekou/Dev/ia-vocal-note-app/$1',
+		),
+	).toThrow(/MCP server config/i)
+})

--- a/packages/workshop-mcp/src/mcp-arg-validation.ts
+++ b/packages/workshop-mcp/src/mcp-arg-validation.ts
@@ -1,0 +1,41 @@
+import { ExpectedMcpError } from './sentry-filters.ts'
+
+/**
+ * Detects literal shell placeholders that an MCP client failed to expand
+ * (e.g. "$1", "${2}", "$WORKSHOP_DIR" as a path segment).
+ */
+const unexpandedShellVariablePattern =
+	/(?:^|[/\\])(\$\{?[0-9]+\}?|\$\{?[A-Za-z_][A-Za-z0-9_]*\}?)(?=$|[/\\])/
+
+export function findUnexpandedShellVariable(value: string): string | null {
+	const match = value.match(unexpandedShellVariablePattern)
+	return match?.[1] ?? null
+}
+
+export function unexpandedShellVariableErrorMessage(
+	argName: string,
+	value: string,
+	token: string,
+) {
+	return (
+		`Received what looks like an unexpanded shell variable (${JSON.stringify(token)}) ` +
+		`for ${argName} (value: ${JSON.stringify(value)}). ` +
+		`This usually means your MCP server config has a literal ${JSON.stringify(token)} in args that the client never substituted. ` +
+		`Replace it with a real value` +
+		(argName === 'workshopDirectory'
+			? ' (an absolute path to the workshop root)'
+			: '') +
+		` instead of a shell placeholder.`
+	)
+}
+
+export function assertNoUnexpandedShellVariable(
+	argName: string,
+	value: string,
+) {
+	const token = findUnexpandedShellVariable(value)
+	if (!token) return
+	throw new ExpectedMcpError(
+		unexpandedShellVariableErrorMessage(argName, value, token),
+	)
+}

--- a/packages/workshop-mcp/src/prompts.ts
+++ b/packages/workshop-mcp/src/prompts.ts
@@ -1,10 +1,11 @@
-import { invariant } from '@epic-web/invariant'
 import { getExercises } from '@epic-web/workshop-utils/apps.server'
 import { getWorkshopConfig } from '@epic-web/workshop-utils/config.server'
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { type GetPromptResult } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod/v3'
+import { assertNoUnexpandedShellVariable } from './mcp-arg-validation.ts'
 import { exerciseContextResource } from './resources.ts'
+import { ExpectedMcpError } from './sentry-filters.ts'
 import { formatPromptDescription, promptDocs } from './server-metadata.ts'
 import {
 	handleWorkshopDirectory,
@@ -35,11 +36,13 @@ export async function quizMe({
 	const config = getWorkshopConfig()
 	let exerciseNumber: number | undefined
 	if (providedExerciseNumber) {
+		assertNoUnexpandedShellVariable('exerciseNumber', providedExerciseNumber)
 		exerciseNumber = Number(providedExerciseNumber)
-		invariant(
-			Number.isFinite(exerciseNumber),
-			`Exercise number must be a number, received "${providedExerciseNumber}".`,
-		)
+		if (!Number.isFinite(exerciseNumber)) {
+			throw new ExpectedMcpError(
+				`Exercise number must be a number, received "${providedExerciseNumber}".`,
+			)
+		}
 	}
 	if (exerciseNumber === undefined) {
 		const exercises = await getExercises()

--- a/packages/workshop-mcp/src/quiz-me.test.ts
+++ b/packages/workshop-mcp/src/quiz-me.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { quizMe } from './prompts.ts'
 import { exerciseContextResource } from './resources.ts'
+import { ExpectedMcpError } from './sentry-filters.ts'
 
 vi.mock('@epic-web/workshop-utils/apps.server', () => ({
 	getExercises: vi.fn(async () => [{ exerciseNumber: 3 }]),
@@ -70,4 +71,17 @@ test('quizMe rejects non-numeric exercise numbers (aha)', async () => {
 	await expect(resultPromise).rejects.toThrow(
 		'Exercise number must be a number',
 	)
+	await expect(resultPromise).rejects.toBeInstanceOf(ExpectedMcpError)
+})
+
+test('quizMe rejects unexpanded shell variables for exerciseNumber (aha)', async () => {
+	const resultPromise = quizMe({
+		workshopDirectory: '/workshop',
+		exerciseNumber: '$2',
+	})
+
+	await expect(resultPromise).rejects.toThrow(
+		/unexpanded shell variable.*"\$2"/i,
+	)
+	await expect(resultPromise).rejects.toBeInstanceOf(ExpectedMcpError)
 })

--- a/packages/workshop-mcp/src/sentry-filters.test.ts
+++ b/packages/workshop-mcp/src/sentry-filters.test.ts
@@ -25,6 +25,30 @@ test('matches required workshop directory messages', () => {
 	)
 })
 
+test('matches historical absolute-path validation messages', () => {
+	expect(
+		isExpectedMcpErrorMessage(
+			'The workshop directory must be an absolute path',
+		),
+	).toBe(true)
+})
+
+test('matches unexpanded shell variable guidance messages', () => {
+	expect(
+		isExpectedMcpErrorMessage(
+			'Received what looks like an unexpanded shell variable ("$1") for workshopDirectory (value: "/tmp/$1"). This usually means your MCP server config has a literal "$1" in args that the client never substituted. Replace it with a real value (an absolute path to the workshop root) instead of a shell placeholder.',
+		),
+	).toBe(true)
+})
+
+test('matches exercise number validation messages', () => {
+	expect(
+		isExpectedMcpErrorMessage(
+			'Exercise number must be a number, received "$2".',
+		),
+	).toBe(true)
+})
+
 test('does not match unrelated errors', () => {
 	expect(isExpectedMcpErrorMessage('Cannot find package zod')).toBe(false)
 })
@@ -66,6 +90,21 @@ test('drops JsonRpcError events that wrap expected workshop messages (aha)', () 
 						type: 'JsonRpcError_-32603',
 						value:
 							'No workshop directory found while searching upward from "/Users/hirotaka/Workspaces/github.com/hirotaka/pragmatic-nuxt/$1" to filesystem root "/"',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('drops JsonRpcError events for historical absolute-path validation (aha)', () => {
+	expect(
+		isExpectedMcpSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'JsonRpcError_-32603',
+						value: 'The workshop directory must be an absolute path',
 					},
 				],
 			},

--- a/packages/workshop-mcp/src/sentry-filters.ts
+++ b/packages/workshop-mcp/src/sentry-filters.ts
@@ -9,6 +9,10 @@ export class ExpectedMcpError extends Error {
 const expectedMcpErrorMessagePatterns = [
 	/^No workshop directory found while searching upward from /,
 	/^The workshop directory is required$/,
+	// Historical message from before relative workshop paths were allowed.
+	/^The workshop directory must be an absolute path$/,
+	/^Received what looks like an unexpanded shell variable /,
+	/^Exercise number must be a number/,
 ]
 
 type SentryExceptionValue = {

--- a/packages/workshop-mcp/src/server-metadata.ts
+++ b/packages/workshop-mcp/src/server-metadata.ts
@@ -49,7 +49,7 @@ Quick start
 
 Default behavior
 - Use \`list_saved_playgrounds\` and \`set_saved_playground\` to restore saved copies when persistence is enabled.
-- \`workshopDirectory\` is required and must be an absolute path to the workshop root.
+- \`workshopDirectory\` is required (absolute path preferred; relative paths resolve from the process cwd). Do not pass unexpanded shell placeholders like \`$1\`.
 - Passing a \`/playground\` path is normalized to the workshop root.
 - The user's work-in-progress lives in the \`playground\` directory.
 - \`get_exercise_context\` defaults to the current playground exercise when \`exerciseNumber\` is omitted.

--- a/packages/workshop-mcp/src/utils.test.ts
+++ b/packages/workshop-mcp/src/utils.test.ts
@@ -115,6 +115,15 @@ test('handleWorkshopDirectory rejects blank input (aha)', async () => {
 	)
 })
 
+test('handleWorkshopDirectory rejects unexpanded shell variables (aha)', async () => {
+	await expect(
+		handleWorkshopDirectory('/home/sekou/Dev/ia-vocal-note-app/$1'),
+	).rejects.toThrow(/unexpanded shell variable.*"\$1"/i)
+	await expect(
+		handleWorkshopDirectory('/home/sekou/Dev/ia-vocal-note-app/$1'),
+	).rejects.toBeInstanceOf(ExpectedMcpError)
+})
+
 test('handleWorkshopDirectory resolves relative paths from cwd (aha)', async () => {
 	await using fixture = await createWorkshopFixture()
 	vi.mocked(console.error).mockImplementation(() => {})

--- a/packages/workshop-mcp/src/utils.ts
+++ b/packages/workshop-mcp/src/utils.ts
@@ -5,6 +5,7 @@ import {
 	init as initApps,
 } from '@epic-web/workshop-utils/apps.server'
 import { z } from 'zod/v3'
+import { assertNoUnexpandedShellVariable } from './mcp-arg-validation.ts'
 import { ExpectedMcpError } from './sentry-filters.ts'
 
 export const workshopDirectoryInputSchema = z
@@ -42,6 +43,8 @@ export async function handleWorkshopDirectory(workshopDirectory: string) {
 	if (!workshopDirectory) {
 		throw new ExpectedMcpError('The workshop directory is required')
 	}
+
+	assertNoUnexpandedShellVariable('workshopDirectory', workshopDirectory)
 
 	if (!path.isAbsolute(workshopDirectory)) {
 		workshopDirectory = path.resolve(process.cwd(), workshopDirectory)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry track **E-1** (`EPICSHOP-EF`, `EPICSHOP-B3`, `EPICSHOP-B1`, `EPICSHOP-FR`): one user’s MCP client was passing literal unexpanded shell placeholders (`$1`, `$2`) into `@epic-web/workshop-mcp`, producing ~1,600 events (~40% of epicshop project volume). Those are caller/config mistakes, not workshop bugs.

This change:
- Detects unexpanded shell placeholders early in `workshopDirectory` / `exerciseNumber` validation
- Returns an `ExpectedMcpError` that tells the user their MCP config has a literal `$1`/`$2` that was never substituted
- Treats exercise-number validation failures as expected MCP errors (not Sentry issues)
- Extends the MCP `beforeSend` filter for the new messages plus the historical `must be an absolute path` message (already fixed by #589 allowing relative paths)

Sibling issues covered and **resolved in Sentry**: `EPICSHOP-EF`, `EPICSHOP-B3` (double-report via mcp-server integration), `EPICSHOP-B1`, `EPICSHOP-FR`.

## Test plan
- [x] `nx run @epic-web/workshop-mcp:test`
- [x] `nx run @epic-web/workshop-mcp:typecheck`
- [x] `nx run @epic-web/workshop-mcp:build`
- [x] CI green on this PR

## Release note
Patch release for `@epic-web/workshop-mcp` (`fix:` commit). Publishes clearer arg-validation errors and keeps those expected failures out of Sentry.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7f4f91c-e952-4b04-a2c3-d6d8942bcbe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7f4f91c-e952-4b04-a2c3-d6d8942bcbe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

