### PR TITLE
fix: filter learner-environment Sentry noise (E-3 hygiene)

### DIFF
--- a/packages/workshop-app/app/utils/monitoring.client.ts
+++ b/packages/workshop-app/app/utils/monitoring.client.ts
@@ -5,7 +5,7 @@ import {
 	useLocation,
 	useNavigationType,
 } from 'react-router'
-import { isProcessingPictureInPictureRequest } from './sentry-filters.ts'
+import { isClientSentryNoise } from './sentry-filters.ts'
 
 // Dynamic import of Sentry with error handling
 const Sentry = await import('@sentry/react-router').catch((error) => {
@@ -76,6 +76,35 @@ function getTracingIntegration(
 	)
 }
 
+function isClientBotUserAgent(userAgent: string) {
+	const normalized = userAgent.toLowerCase()
+	const botKeywords = [
+		'bot',
+		'crawl',
+		'spider',
+		'scrape',
+		'fetch',
+		'monitor',
+		'test',
+		'headless',
+		'phantom',
+		'puppeteer',
+		'selenium',
+		'webdriver',
+		'lighthouse',
+		'pagespeed',
+		'facebookexternalhit',
+		'twitterbot',
+		'googlebot',
+		'bingbot',
+		'slackbot',
+		'whatsapp',
+		'linkedinbot',
+		'applebot',
+	]
+	return botKeywords.some((keyword) => normalized.includes(keyword))
+}
+
 export function init() {
 	if (!ENV.EPICSHOP_IS_PUBLISHED) return
 	if (!Sentry) return
@@ -103,86 +132,30 @@ export function init() {
 		tracePropagationTargets,
 		ignoreErrors: [
 			"Failed to execute 'requestPictureInPicture' on 'HTMLVideoElement'",
+			/^AbortError/,
+			/signal is aborted without reason/i,
+			/BodyStreamBuffer was aborted/i,
+			/Fetch is aborted/i,
+			/The operation was aborted/i,
+			/Failed to fetch/i,
+			/NetworkError when attempting to fetch resource/i,
+			/^Load failed/i,
 		],
 		beforeSend(event) {
-			if (isProcessingPictureInPictureRequest(event)) return null
+			if (isClientSentryNoise(event)) return null
 
 			// Don't send errors to Sentry for bot requests
 			if (typeof navigator !== 'undefined' && navigator.userAgent) {
-				// Basic bot detection for client-side - check for common bot indicators
-				const userAgent = navigator.userAgent.toLowerCase()
-				const botKeywords = [
-					'bot',
-					'crawl',
-					'spider',
-					'scrape',
-					'fetch',
-					'monitor',
-					'test',
-					'headless',
-					'phantom',
-					'puppeteer',
-					'selenium',
-					'webdriver',
-					'lighthouse',
-					'pagespeed',
-					'facebookexternalhit',
-					'twitterbot',
-					'googlebot',
-					'bingbot',
-					'slackbot',
-					'whatsapp',
-					'linkedinbot',
-				]
-				if (botKeywords.some((keyword) => userAgent.includes(keyword))) {
+				if (isClientBotUserAgent(navigator.userAgent)) {
 					return null
 				}
 			}
 
-			const domMutationErrors =
-				event.exception?.values?.some((value) => {
-					if (typeof value.value !== 'string') return false
-					return /insertBefore/i.test(value.value)
-						? true
-						: /removeChild/i.test(value.value)
-				}) ?? false
-			if (domMutationErrors) return null
-
-			// Very common when learners shut down the local server and the browser keeps trying to fetch
-			const failedToFetch =
-				event.exception?.values?.some(
-					(v) =>
-						typeof v.value === 'string' && /Failed to fetch/i.test(v.value),
-				) ?? false
-
-			if (failedToFetch && !ENV.EPICSHOP_DEPLOYED) return null
-
-			// Filter out browser extension related errors
-			const extensionError = event.exception?.values?.some((value) =>
-				value.stacktrace?.frames?.some(
-					(frame) =>
-						frame.filename?.includes('chrome-extension:') ||
-						frame.filename?.includes('moz-extension:'),
-				),
-			)
-			if (extensionError) return null
-
-			// Filter out errors containing browser extension globals
-			const extensionGlobalKeywords = ['__firefox__', 'ethereum']
-			const extensionGlobalError = event.exception?.values?.some(
-				(value) =>
-					typeof value.value === 'string' &&
-					extensionGlobalKeywords.some((keyword) =>
-						value.value?.includes(keyword),
-					),
-			)
-			if (extensionGlobalError) return null
-			if (event.request?.url) {
-				const url = new URL(event.request.url)
-				if (
-					url.protocol === 'chrome-extension:' ||
-					url.protocol === 'moz-extension:'
-				) {
+			return event
+		},
+		beforeSendTransaction(event) {
+			if (typeof navigator !== 'undefined' && navigator.userAgent) {
+				if (isClientBotUserAgent(navigator.userAgent)) {
 					return null
 				}
 			}

--- a/packages/workshop-app/app/utils/sentry-filters.ts
+++ b/packages/workshop-app/app/utils/sentry-filters.ts
@@ -1,25 +1,179 @@
 type SentryExceptionValue = {
 	type?: string
 	value?: string
+	stacktrace?: {
+		frames?: Array<{
+			filename?: string
+			function?: string
+		}>
+	}
 }
 
 type SentryEventWithException = {
 	exception?: {
 		values?: Array<SentryExceptionValue>
 	}
+	request?: {
+		url?: string
+	}
 }
 
 export const processingPictureInPictureRequestMessage =
 	'The video element is processing a Picture-in-Picture request.'
 
+function getExceptionValues(event: SentryEventWithException) {
+	return event.exception?.values ?? []
+}
+
+function exceptionValueText(value: SentryExceptionValue) {
+	return typeof value.value === 'string' ? value.value : ''
+}
+
 export function isProcessingPictureInPictureRequest(
 	event: SentryEventWithException,
 ) {
+	return getExceptionValues(event).some(
+		(value) =>
+			value.type === 'NotAllowedError' &&
+			value.value === processingPictureInPictureRequestMessage,
+	)
+}
+
+/**
+ * Learners navigate away / HMR reloads / connection-status polls abort in-flight
+ * fetches. These AbortErrors are not actionable product defects.
+ */
+export function isAbortErrorNoise(event: SentryEventWithException) {
+	return getExceptionValues(event).some((value) => {
+		if (value.type === 'AbortError') return true
+		const text = exceptionValueText(value)
+		return (
+			/signal is aborted without reason/i.test(text) ||
+			/BodyStreamBuffer was aborted/i.test(text) ||
+			/Fetch is aborted/i.test(text) ||
+			/The operation was aborted/i.test(text)
+		)
+	})
+}
+
+/**
+ * Browser/network blips while the local (or hosted) workshop server flaps,
+ * the tab sleeps, or the learner's connection drops mid-fetch.
+ */
+export function isBrowserNetworkNoise(event: SentryEventWithException) {
+	return getExceptionValues(event).some((value) => {
+		const text = exceptionValueText(value)
+		if (!text) return false
+		return (
+			/Failed to fetch/i.test(text) ||
+			/NetworkError when attempting to fetch resource/i.test(text) ||
+			/^Load failed/i.test(text) ||
+			/^network error$/i.test(text) ||
+			/^fetch failed$/i.test(text) ||
+			/^terminated$/i.test(text) ||
+			value.type === 'NS_ERROR_NOT_AVAILABLE'
+		)
+	})
+}
+
+export function isSessionStorageAccessDenied(event: SentryEventWithException) {
+	return getExceptionValues(event).some((value) => {
+		const text = exceptionValueText(value)
+		return (
+			value.type === 'SecurityError' &&
+			/sessionStorage/i.test(text) &&
+			/Access is denied/i.test(text)
+		)
+	})
+}
+
+export function isCrossOriginSecurityNoise(event: SentryEventWithException) {
+	return getExceptionValues(event).some((value) => {
+		const text = exceptionValueText(value)
+		if (value.type === 'SecurityError' && /cross-origin/i.test(text)) {
+			return true
+		}
+		return /Permission denied to access property/i.test(text)
+	})
+}
+
+export function isBrowserExtensionNoise(event: SentryEventWithException) {
+	const extensionGlobalKeywords = ['__firefox__', 'ethereum']
+	const extensionFrameHints = [
+		'chrome-extension:',
+		'moz-extension:',
+		'contentScriptVisibilityChanged',
+		'addEL_hook',
+		'inBrowserBrowserRef',
+	]
+
+	for (const value of getExceptionValues(event)) {
+		const text = exceptionValueText(value)
+		if (
+			extensionGlobalKeywords.some((keyword) => text.includes(keyword)) ||
+			/contentScriptVisibilityChanged/i.test(text) ||
+			/inBrowserBrowserRef/i.test(text)
+		) {
+			return true
+		}
+
+		const frames = value.stacktrace?.frames ?? []
+		if (
+			frames.some((frame) => {
+				const filename = frame.filename ?? ''
+				const fn = frame.function ?? ''
+				return extensionFrameHints.some(
+					(hint) => filename.includes(hint) || fn.includes(hint),
+				)
+			})
+		) {
+			return true
+		}
+	}
+
+	if (event.request?.url) {
+		try {
+			const url = new URL(event.request.url)
+			if (
+				url.protocol === 'chrome-extension:' ||
+				url.protocol === 'moz-extension:'
+			) {
+				return true
+			}
+		} catch {
+			// ignore invalid URLs
+		}
+	}
+
+	return false
+}
+
+export function isDomMutationNoise(event: SentryEventWithException) {
+	return getExceptionValues(event).some((value) => {
+		const text = exceptionValueText(value)
+		if (!text) return false
+		return /insertBefore/i.test(text) || /removeChild/i.test(text)
+	})
+}
+
+/** Learner playground / exercise sandbox code should not page on-call. */
+export function isPlaygroundClientNoise(event: SentryEventWithException) {
+	return getExceptionValues(event).some((value) =>
+		value.stacktrace?.frames?.some((frame) =>
+			frame.filename?.includes('/playground/'),
+		),
+	)
+}
+
+export function isClientSentryNoise(event: SentryEventWithException) {
 	return (
-		event.exception?.values?.some(
-			(value) =>
-				value.type === 'NotAllowedError' &&
-				value.value === processingPictureInPictureRequestMessage,
-		) ?? false
+		isProcessingPictureInPictureRequest(event) ||
+		isAbortErrorNoise(event) ||
+		isBrowserNetworkNoise(event) ||
+		isSessionStorageAccessDenied(event) ||
+		isCrossOriginSecurityNoise(event) ||
+		isBrowserExtensionNoise(event) ||
+		isDomMutationNoise(event) ||
+		isPlaygroundClientNoise(event)
 	)
 }

--- a/packages/workshop-app/app/utils/sentry-filters.ts
+++ b/packages/workshop-app/app/utils/sentry-filters.ts
@@ -62,6 +62,9 @@ export function isAbortErrorNoise(event: SentryEventWithException) {
  */
 export function isBrowserNetworkNoise(event: SentryEventWithException) {
 	return getExceptionValues(event).some((value) => {
+		// Firefox often reports this network abort with an empty message.
+		if (value.type === 'NS_ERROR_NOT_AVAILABLE') return true
+
 		const text = exceptionValueText(value)
 		if (!text) return false
 		return (
@@ -70,8 +73,7 @@ export function isBrowserNetworkNoise(event: SentryEventWithException) {
 			/^Load failed/i.test(text) ||
 			/^network error$/i.test(text) ||
 			/^fetch failed$/i.test(text) ||
-			/^terminated$/i.test(text) ||
-			value.type === 'NS_ERROR_NOT_AVAILABLE'
+			/^terminated$/i.test(text)
 		)
 	})
 }

--- a/packages/workshop-app/instrument.js
+++ b/packages/workshop-app/instrument.js
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { isbot } from 'isbot'
+import { isServerEnvironmentNoise } from './sentry-server-filters.js'
 
 // Dynamic import of Sentry modules with error handling
 const Sentry = await import('@sentry/react-router').catch((error) => {
@@ -77,6 +78,9 @@ Sentry?.init({
 			return null
 		}
 		if (isLearnerApiRequest(event)) {
+			return null
+		}
+		if (isServerEnvironmentNoise(event)) {
 			return null
 		}
 		const isPlaygroundError = event.exception?.values?.some((value) =>

--- a/packages/workshop-app/sentry-server-filters.d.ts
+++ b/packages/workshop-app/sentry-server-filters.d.ts
@@ -1,0 +1,8 @@
+export function isServerEnvironmentNoise(event: {
+	exception?: {
+		values?: Array<{
+			type?: string
+			value?: string
+		}>
+	}
+}): boolean

--- a/packages/workshop-app/sentry-server-filters.js
+++ b/packages/workshop-app/sentry-server-filters.js
@@ -1,0 +1,31 @@
+/**
+ * Server-side Sentry noise that comes from learner machines (flaky disks,
+ * aborted local networks, OS handle exhaustion) rather than product bugs.
+ */
+
+/**
+ * @param {{ exception?: { values?: Array<{ type?: string, value?: string }> } }} event
+ */
+export function isServerEnvironmentNoise(event) {
+	const values = event.exception?.values ?? []
+	return values.some((value) => {
+		const type = value.type ?? ''
+		const text = typeof value.value === 'string' ? value.value : ''
+		if (!text && !type) return false
+
+		if (type === 'TimeoutError' && /Task timed out after/i.test(text)) {
+			return true
+		}
+
+		return (
+			/ETIMEDOUT: connection timed out/i.test(text) ||
+			/\bECONNRESET\b/i.test(text) ||
+			/\bECONNREFUSED\b/i.test(text) ||
+			/\bENOTFOUND\b/i.test(text) ||
+			/socket hang up/i.test(text) ||
+			/^spawn EBADF$/i.test(text) ||
+			/^EPERM: operation not permitted/i.test(text) ||
+			/^ENOENT: no such file or directory/i.test(text)
+		)
+	})
+}

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -116,6 +116,13 @@ test('drops browser network flap messages even when deployed (aha)', () => {
 			},
 		}),
 	).toBe(true)
+	expect(
+		isBrowserNetworkNoise({
+			exception: {
+				values: [{ type: 'NS_ERROR_NOT_AVAILABLE', value: '' }],
+			},
+		}),
+	).toBe(true)
 })
 
 test('drops sessionStorage SecurityError access denials', () => {

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -1,8 +1,17 @@
 import { expect, test } from 'vitest'
 import {
+	isAbortErrorNoise,
+	isBrowserExtensionNoise,
+	isBrowserNetworkNoise,
+	isClientSentryNoise,
+	isCrossOriginSecurityNoise,
+	isDomMutationNoise,
+	isPlaygroundClientNoise,
 	isProcessingPictureInPictureRequest,
+	isSessionStorageAccessDenied,
 	processingPictureInPictureRequestMessage,
 } from '../app/utils/sentry-filters.ts'
+import { isServerEnvironmentNoise } from '../sentry-server-filters.js'
 
 test('matches the Picture-in-Picture processing DOMException exactly', () => {
 	expect(
@@ -44,6 +53,247 @@ test('does not match the same message on a different exception type', () => {
 						value: processingPictureInPictureRequestMessage,
 					},
 				],
+			},
+		}),
+	).toBe(false)
+})
+
+test('drops AbortError navigation/fetch aborts (aha)', () => {
+	expect(
+		isAbortErrorNoise({
+			exception: {
+				values: [
+					{ type: 'AbortError', value: 'signal is aborted without reason' },
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isAbortErrorNoise({
+			exception: {
+				values: [{ type: 'AbortError', value: 'BodyStreamBuffer was aborted' }],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isAbortErrorNoise({
+			exception: {
+				values: [{ type: 'Error', value: 'Fetch is aborted' }],
+			},
+		}),
+	).toBe(true)
+})
+
+test('drops browser network flap messages even when deployed (aha)', () => {
+	expect(
+		isBrowserNetworkNoise({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: 'Failed to fetch (fundamentals.epicreact.dev)',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isBrowserNetworkNoise({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: 'NetworkError when attempting to fetch resource.',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isBrowserNetworkNoise({
+			exception: {
+				values: [{ type: 'TypeError', value: 'Load failed' }],
+			},
+		}),
+	).toBe(true)
+})
+
+test('drops sessionStorage SecurityError access denials', () => {
+	expect(
+		isSessionStorageAccessDenied({
+			exception: {
+				values: [
+					{
+						type: 'SecurityError',
+						value:
+							"Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.",
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('drops cross-origin / permission-denied browser sandbox noise', () => {
+	expect(
+		isCrossOriginSecurityNoise({
+			exception: {
+				values: [
+					{
+						type: 'SecurityError',
+						value:
+							'Permission denied to access property "Element" on cross-origin object',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isCrossOriginSecurityNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Permission denied to access property "apply"',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('drops browser extension hooks and content-script timeouts (aha)', () => {
+	expect(
+		isBrowserExtensionNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value:
+							'Request timeout for contentScriptVisibilityChanged (contentScriptVisibilityChanged 0e0962)',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isBrowserExtensionNoise({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"Cannot destructure property 'inBrowserBrowserRef' from null or undefined value",
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isBrowserExtensionNoise({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of null (reading 'tagName')",
+						stacktrace: {
+							frames: [{ filename: '<anonymous>', function: 'addEL_hook' }],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('drops DOM mutation races and playground client frames', () => {
+	expect(
+		isDomMutationNoise({
+			exception: {
+				values: [
+					{
+						type: 'NotFoundError',
+						value:
+							"Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isPlaygroundClientNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value:
+							'Could not determine window of node. Node was [object HTMLButtonElement]',
+						stacktrace: {
+							frames: [
+								{
+									filename: '/app/playground/error-boundary.test.ts',
+									function: 'getWindow',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('isClientSentryNoise aggregates the client predicates', () => {
+	expect(
+		isClientSentryNoise({
+			exception: {
+				values: [{ type: 'AbortError', value: 'The operation was aborted.' }],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isClientSentryNoise({
+			exception: {
+				values: [{ type: 'TypeError', value: 'Maximum update depth exceeded' }],
+			},
+		}),
+	).toBe(false)
+})
+
+test('drops learner-machine server environment noise (aha)', () => {
+	expect(
+		isServerEnvironmentNoise({
+			exception: {
+				values: [
+					{ type: 'Error', value: 'ETIMEDOUT: connection timed out, read' },
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isServerEnvironmentNoise({
+			exception: {
+				values: [{ type: 'Error', value: 'spawn EBADF' }],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isServerEnvironmentNoise({
+			exception: {
+				values: [
+					{
+						type: 'TimeoutError',
+						value:
+							'Task timed out after 60000ms (queue has 1 running, 0 waiting)',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isServerEnvironmentNoise({
+			exception: {
+				values: [{ type: 'Error', value: 'Unexpected Server Error' }],
 			},
 		}),
 	).toBe(false)

--- a/packages/workshop-app/vitest.sentry-noise.config.ts
+++ b/packages/workshop-app/vitest.sentry-noise.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
 		setupFiles: ['../../tests/vitest-setup.ts'],
 		mockReset: true,
 	},
+	resolve: {
+		extensions: ['.js', '.ts', '.tsx'],
+	},
 })

--- a/packages/workshop-cli/src/utils/sentry-cli-filters.test.ts
+++ b/packages/workshop-cli/src/utils/sentry-cli-filters.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from 'vitest'
+import { isExpectedCliSentryNoise } from './sentry-cli-filters.ts'
+
+test('drops non-interactive TTY guard errors (aha)', () => {
+	expect(
+		isExpectedCliSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: '❌ Non-interactive environment: no TTY detected.',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('drops Ctrl-C ExitPromptError cancellations', () => {
+	expect(
+		isExpectedCliSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'ExitPromptError',
+						value: 'User force closed the prompt with SIGINT',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('drops unsupported Node styleText and broken local package installs', () => {
+	expect(
+		isExpectedCliSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value:
+							"The requested module 'node:util' does not provide an export named 'styleText'",
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isExpectedCliSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value:
+							"Cannot find package 'zod' imported from /Users/cal/Library/pnpm/store/v11/links/@/epicshop/6.90.11/x",
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('keeps unrelated CLI errors', () => {
+	expect(
+		isExpectedCliSentryNoise({
+			exception: {
+				values: [{ type: 'Error', value: 'Failed to clone workshop repo' }],
+			},
+		}),
+	).toBe(false)
+})

--- a/packages/workshop-cli/src/utils/sentry-cli-filters.ts
+++ b/packages/workshop-cli/src/utils/sentry-cli-filters.ts
@@ -1,0 +1,44 @@
+type SentryExceptionValue = {
+	type?: string
+	value?: string
+}
+
+type SentryEventWithException = {
+	exception?: {
+		values?: Array<SentryExceptionValue>
+	}
+}
+
+function getExceptionValues(event: SentryEventWithException) {
+	return event.exception?.values ?? []
+}
+
+function exceptionValueText(value: SentryExceptionValue) {
+	return typeof value.value === 'string' ? value.value : ''
+}
+
+/**
+ * Expected CLI UX: user ran an interactive command without a TTY / in CI, or
+ * cancelled an inquirer prompt with Ctrl-C. Not a product defect.
+ */
+export function isExpectedCliSentryNoise(event: SentryEventWithException) {
+	return getExceptionValues(event).some((value) => {
+		const type = value.type ?? ''
+		const text = exceptionValueText(value)
+
+		if (type === 'ExitPromptError') return true
+		if (/User force closed the prompt with SIGINT/i.test(text)) return true
+		if (/Non-interactive environment: no TTY detected/i.test(text)) return true
+		if (/CI mode: prompts are disabled/i.test(text)) return true
+
+		// Unsupported / broken learner Node installs
+		if (
+			/does not provide an export named 'styleText'/i.test(text) ||
+			/Cannot find package '/i.test(text)
+		) {
+			return true
+		}
+
+		return false
+	})
+}

--- a/packages/workshop-cli/src/utils/sentry-cli.ts
+++ b/packages/workshop-cli/src/utils/sentry-cli.ts
@@ -1,5 +1,6 @@
 import { getEnv } from '@epic-web/workshop-utils/init-env'
 import * as Sentry from '@sentry/node'
+import { isExpectedCliSentryNoise } from './sentry-cli-filters.js'
 
 type CliCommandContext = {
 	command?: string
@@ -136,6 +137,10 @@ export function initCliSentry(args: string[]): CliSentry {
 		sendDefaultPii: false,
 		environment: env.EPICSHOP_IS_PUBLISHED ? 'production' : 'development',
 		tracesSampleRate: 1,
+		beforeSend(event) {
+			if (isExpectedCliSentryNoise(event)) return null
+			return event
+		},
 	})
 
 	Sentry.setTags({

--- a/packages/workshop-mcp/src/sentry-filters.test.ts
+++ b/packages/workshop-mcp/src/sentry-filters.test.ts
@@ -49,6 +49,14 @@ test('matches exercise number validation messages', () => {
 	).toBe(true)
 })
 
+test('matches Electron-host JSON-RPC stdio corruption (aha)', () => {
+	expect(
+		isExpectedMcpErrorMessage(
+			`Unexpected token 'E', " ELECTRON_R"... is not valid JSON`,
+		),
+	).toBe(true)
+})
+
 test('does not match unrelated errors', () => {
 	expect(isExpectedMcpErrorMessage('Cannot find package zod')).toBe(false)
 })

--- a/packages/workshop-mcp/src/sentry-filters.ts
+++ b/packages/workshop-mcp/src/sentry-filters.ts
@@ -13,6 +13,9 @@ const expectedMcpErrorMessagePatterns = [
 	/^The workshop directory must be an absolute path$/,
 	/^Received what looks like an unexpanded shell variable /,
 	/^Exercise number must be a number/,
+	// Electron/Cursor host sometimes prepends env noise onto MCP stdio JSON-RPC frames
+	/ELECTRON_R.*is not valid JSON/i,
+	/Unexpected token 'E', " ELECTRON_R"/i,
 ]
 
 type SentryExceptionValue = {
@@ -37,6 +40,16 @@ export function isExpectedMcpSentryNoise(
 	hint?: { originalException?: unknown },
 ) {
 	if (hint?.originalException instanceof ExpectedMcpError) return true
+
+	if (
+		hint?.originalException &&
+		typeof hint.originalException === 'object' &&
+		'message' in hint.originalException &&
+		typeof hint.originalException.message === 'string' &&
+		isExpectedMcpErrorMessage(hint.originalException.message)
+	) {
+		return true
+	}
 
 	return (
 		event.exception?.values?.some((value) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Track **E-3** (`epicshop-sentry-hygiene`) for the Kent C. Dodds Sentry cleanup program.

Epicshop’s open issue stream was dominated by learner-laptop noise (aborted fetches, local network flaps, browser extensions, CLI TTY/SIGINT UX, MCP Electron stdio corruption, and local Node filesystem/timeouts), plus AI/performance insight issue types that are not actionable for this local workshop app.

This PR adds **narrow SDK `beforeSend` / `ignoreErrors` filters** (with tests) across:

- **Client** (`monitoring.client.ts` + `sentry-filters.ts`): AbortError, Failed to fetch / NetworkError / Load failed, sessionStorage / cross-origin SecurityErrors, extension hooks (`contentScriptVisibilityChanged`, `addEL_hook`, `inBrowserBrowserRef`), DOM mutation races, playground frames; also drop bot transactions via `beforeSendTransaction`.
- **Server** (`instrument.js` + `sentry-server-filters.js`): ETIMEDOUT, ECONN*, spawn EBADF, EPERM/ENOENT, p-queue TimeoutError.
- **CLI** (`sentry-cli-filters.ts`): non-interactive TTY / CI prompt guards, ExitPromptError SIGINT, unsupported Node `styleText`, broken local `Cannot find package`.
- **MCP** (`sentry-filters.ts`): Electron `" ELECTRON_R"... is not valid JSON` stdio corruption (rebased onto E-1’s absolute-path / shell-var / exercise-number filters from #628).

## Sentry project settings (already applied via API)

- Enabled inbound **browser-extensions** filter.
- Disabled **AI issue detection** and **large render blocking asset** detection for `epicshop`.

## Triage already applied

- **67 filtered** (+ comment) archived forever after SDK/project filters.
- **3 ignored** one-offs (`G5`, `F7`, `F8`).
- **~25 left open** as recommendations for E-1 (ZodErrors) / E-2 (router/request pipeline, React update-depth, ByteString PE).

## Risk

**Medium** (merge publishes npm packages with provenance). Filters are drop-only and covered by unit tests; no auth/payment/data-deletion surface. High confidence to squash-merge once CI is green post-rebase.

## Test plan

- [x] `npm test -- --project app-sentry-noise`
- [x] MCP + CLI sentry filter unit tests
- [x] typecheck for app / cli / mcp
- [ ] CI green after rebase onto #628

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65d2413e-c2bd-4455-b967-933a7d464703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65d2413e-c2bd-4455-b967-933a7d464703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

