### PR TITLE
fix: turn malformed and client-error requests into 4xx instead of reported 500s

### DIFF
--- a/packages/workshop-app/app/entry.server.tsx
+++ b/packages/workshop-app/app/entry.server.tsx
@@ -20,6 +20,7 @@ import {
 	type LoaderFunctionArgs,
 	type ActionFunctionArgs,
 } from 'react-router'
+import { isClientErrorResponse } from './utils/route-errors'
 import { getSentryUser } from './utils/sentry-user'
 
 export const streamTimeout = 60000
@@ -32,6 +33,8 @@ export async function handleError(
 	if (request.signal.aborted) return
 	// Don't send errors to Sentry for bot requests
 	if (isbot(request.headers.get('user-agent'))) return
+	// Don't send React Router's own client 4xx responses to Sentry
+	if (isClientErrorResponse(error)) return
 	if (ENV.EPICSHOP_IS_PUBLISHED) {
 		const Sentry = await sentryPromise
 		if (Sentry) {

--- a/packages/workshop-app/app/routes/$.tsx
+++ b/packages/workshop-app/app/routes/$.tsx
@@ -12,8 +12,11 @@ import { Icon } from '#app/components/icons.tsx'
 
 export async function loader({ params }: Route.LoaderArgs) {
 	const splat = params['*']
-	const segments = splat?.split('/') ?? []
-	if (segments.length > 0 && !isNaN(Number(segments[0]))) {
+	// Only a bare run of digits counts as an exercise number. `Number('')` is 0,
+	// so the old isNaN check let `//anything` through and built a Location
+	// header out of it.
+	const [firstSegment] = splat?.split('/') ?? []
+	if (firstSegment && /^\d+$/.test(firstSegment)) {
 		const newPath = `/exercise/${splat}`
 		return new Response(null, {
 			status: 302,

--- a/packages/workshop-app/app/routes/_app+/app.$appName+/api.$.ts
+++ b/packages/workshop-app/app/routes/_app+/app.$appName+/api.$.ts
@@ -21,10 +21,9 @@ export async function loader(args: Route.LoaderArgs) {
 		{ status: 405 },
 	)
 	try {
-		const result = await loaderFn(args)
-		return result
+		return await loaderFn(args)
 	} catch (error) {
-		api.cleanupError(error)
+		throw api.toLearnerErrorResponse(error)
 	}
 }
 
@@ -40,10 +39,9 @@ export async function action(args: Route.ActionArgs) {
 		{ status: 405 },
 	)
 	try {
-		const result = await actionFn(args)
-		return result
+		return await actionFn(args)
 	} catch (error) {
-		api.cleanupError(error)
+		throw api.toLearnerErrorResponse(error)
 	}
 }
 
@@ -102,7 +100,9 @@ async function getApiModule({ request, params }: Route.LoaderArgs) {
 	}
 	const apiCode = outputFiles[0].text
 	const dataUrl = `data:text/javascript;base64,${Buffer.from(apiCode).toString('base64')}`
-	const mod = await import(/* @vite-ignore */ dataUrl).catch(cleanupError)
+	const mod = await import(/* @vite-ignore */ dataUrl).catch((error) => {
+		throw toLearnerErrorResponse(error)
+	})
 	const apiModule = ApiModuleSchema.safeParse(mod)
 	if (!apiModule.success) {
 		throw new Response(
@@ -112,13 +112,26 @@ async function getApiModule({ request, params }: Route.LoaderArgs) {
 	}
 	return {
 		mod: apiModule.data,
-		cleanupError,
+		toLearnerErrorResponse,
 	}
 
-	function cleanupError(error: unknown) {
+	// Anything thrown here comes from the learner's own api.server file, not
+	// from epicshop. React Router hands a thrown Response straight back to the
+	// client without running the server `handleError` hook, so turning the
+	// failure into a Response keeps the learner's bug out of our error
+	// reporting while still showing it to them.
+	function toLearnerErrorResponse(error: unknown) {
+		if (error instanceof Response) return error
 		if (apiFile && error instanceof Error && error.stack) {
 			error.stack = error.stack.replace(dataUrl, apiFile)
 		}
-		throw error
+		console.error(`Error in ${apiFile}:`, error)
+		return new Response(
+			error instanceof Error ? error.message : String(error),
+			{
+				status: 500,
+				headers: { 'Content-Type': 'text/plain' },
+			},
+		)
 	}
 }

--- a/packages/workshop-app/app/routes/launch-editor.tsx
+++ b/packages/workshop-app/app/routes/launch-editor.tsx
@@ -26,14 +26,36 @@ function getFileDescriptorSchema<AppFile extends ZodTypeAny>(appFile: AppFile) {
 	])
 }
 
-const LaunchSchema = z.intersection(
+// The cursor hints arrive as form values, so anything that isn't a run of
+// digits means "no hint" rather than a bad request. `z.coerce.number()` turned
+// an empty value into line 0 and a stray `"false"` into a request-failing NaN.
+const cursorHint = z.preprocess(
+	(value) =>
+		typeof value === 'string' && /^\d+$/.test(value)
+			? Number(value)
+			: undefined,
+	z.number().optional(),
+)
+
+export const LaunchSchema = z.intersection(
 	z.object({
-		line: z.coerce.number().optional(),
-		column: z.coerce.number().optional(),
+		line: cursorHint,
+		column: cursorHint,
 		syncTo: getFileDescriptorSchema(z.string()).optional(),
 	}),
 	getFileDescriptorSchema(z.array(z.string())),
 )
+
+function formatIssues(error: z.ZodError) {
+	// Zod nests each branch's issues under a single `invalid_union` issue, so
+	// flatten one level to say something more useful than "Invalid input".
+	return error.issues
+		.flatMap((issue) =>
+			issue.code === 'invalid_union' ? issue.errors.flat() : [issue],
+		)
+		.map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+		.join('; ')
+}
 
 export async function action({ request }: Route.ActionArgs) {
 	ensureUndeployed()
@@ -80,7 +102,9 @@ export async function action({ request }: Route.ActionArgs) {
 	}
 	const parsedForm = LaunchSchema.safeParse(rawData)
 	if (!parsedForm.success) {
-		throw parsedForm.error
+		// Throwing the ZodError itself makes React Router treat bad client input
+		// as an unhandled server fault: a 500 plus an error report.
+		throw new Response(formatIssues(parsedForm.error), { status: 400 })
 	}
 	const form = parsedForm.data
 
@@ -266,9 +290,13 @@ function LaunchEditorImpl({
 			<input
 				type="hidden"
 				name="line"
-				value={typeof line === 'number' ? line : undefined}
+				value={typeof line === 'number' ? line : ''}
 			/>
-			<input type="hidden" name="column" value={column} />
+			<input
+				type="hidden"
+				name="column"
+				value={typeof column === 'number' ? column : ''}
+			/>
 			<input type="hidden" name="type" value={type} />
 			<input type="hidden" name="file" value={file} />
 			<input type="hidden" name="appName" value={appName} />

--- a/packages/workshop-app/app/routes/resources+/lookout.ts
+++ b/packages/workshop-app/app/routes/resources+/lookout.ts
@@ -13,12 +13,22 @@ export function loader() {
 	})
 }
 
+function parseEnvelopeHeader(piece: string) {
+	try {
+		return JSON.parse(piece) as { dsn: string }
+	} catch {
+		// A SyntaxError here would escape as a reported 500, but a body that
+		// isn't a Sentry envelope is the caller's mistake.
+		throw new Response('Invalid sentry envelope', { status: 400 })
+	}
+}
+
 export async function action({ request }: Route.ActionArgs) {
 	const envelope = await request.text()
 	const piece = envelope.split('\n')[0]
 	invariantResponse(piece, 'no piece in envelope')
 
-	const header = JSON.parse(piece ?? '{}') as any
+	const header = parseEnvelopeHeader(piece)
 	const dsn = new URL(header.dsn)
 	const projectId = dsn.pathname?.replace('/', '')
 

--- a/packages/workshop-app/app/routes/resources+/lookout.ts
+++ b/packages/workshop-app/app/routes/resources+/lookout.ts
@@ -4,6 +4,15 @@ import { type Route } from './+types/lookout'
 const SENTRY_HOST = new URL(ENV.SENTRY_DSN).hostname
 const SENTRY_PROJECT_IDS = [ENV.SENTRY_PROJECT_ID]
 
+// This route only accepts POST, but without a loader React Router turns a GET
+// into a reported internal server error instead of a 405.
+export function loader() {
+	return new Response('Method Not Allowed', {
+		status: 405,
+		headers: { Allow: 'POST' },
+	})
+}
+
 export async function action({ request }: Route.ActionArgs) {
 	const envelope = await request.text()
 	const piece = envelope.split('\n')[0]

--- a/packages/workshop-app/app/utils/route-errors.ts
+++ b/packages/workshop-app/app/utils/route-errors.ts
@@ -1,0 +1,11 @@
+import { isRouteErrorResponse } from 'react-router'
+
+// React Router reports its own internal 4xx ErrorResponses (unroutable URL,
+// missing loader/action for the method) through the server handleError hook
+// even though it has already answered the request with that 4xx status, so
+// they are client mistakes, not server faults.
+export function isClientErrorResponse(error: unknown) {
+	return (
+		isRouteErrorResponse(error) && error.status >= 400 && error.status < 500
+	)
+}

--- a/packages/workshop-app/server/index.ts
+++ b/packages/workshop-app/server/index.ts
@@ -30,6 +30,7 @@ import morgan from 'morgan'
 import { type ServerBuild } from 'react-router'
 import sourceMapSupport from 'source-map-support'
 import { type WebSocket, WebSocketServer } from 'ws'
+import { rejectMalformedRequests } from './malformed-request.ts'
 
 // if we exit early with an error, log the error...
 closeWithGrace(({ err, manual }) => {
@@ -86,6 +87,8 @@ app.use(compression())
 
 // http://expressjs.com/en/advanced/best-practice-security.html#at-a-minimum-disable-x-powered-by-header
 app.disable('x-powered-by')
+
+app.use(rejectMalformedRequests)
 
 // the workshop's public assets override the app's public assets
 app.use(

--- a/packages/workshop-app/server/index.ts
+++ b/packages/workshop-app/server/index.ts
@@ -30,7 +30,10 @@ import morgan from 'morgan'
 import { type ServerBuild } from 'react-router'
 import sourceMapSupport from 'source-map-support'
 import { type WebSocket, WebSocketServer } from 'ws'
-import { rejectMalformedRequests } from './malformed-request.ts'
+import {
+	decodeRequestTarget,
+	rejectMalformedRequests,
+} from './malformed-request.ts'
 
 // if we exit early with an error, log the error...
 closeWithGrace(({ err, manual }) => {
@@ -114,7 +117,7 @@ if (
 	ENV.EPICSHOP_DEPLOYED ||
 	debuglog('epic:req').enabled
 ) {
-	morgan.token('url', (req) => decodeURIComponent(req.url ?? ''))
+	morgan.token('url', (req) => decodeRequestTarget(req.url ?? ''))
 	const ignore = [/^\/__manifest/]
 	app.use(
 		morgan('tiny', {

--- a/packages/workshop-app/server/malformed-request.ts
+++ b/packages/workshop-app/server/malformed-request.ts
@@ -38,6 +38,16 @@ export function getMalformedRequestReason(
 	return null
 }
 
+// morgan logs from an on-finished listener, so letting decodeURIComponent
+// throw there is an uncaught exception that takes the whole process down.
+export function decodeRequestTarget(requestTarget: string) {
+	try {
+		return decodeURIComponent(requestTarget)
+	} catch {
+		return requestTarget
+	}
+}
+
 export function rejectMalformedRequests(
 	req: Request,
 	res: Response,

--- a/packages/workshop-app/server/malformed-request.ts
+++ b/packages/workshop-app/server/malformed-request.ts
@@ -1,0 +1,52 @@
+import { type NextFunction, type Request, type Response } from 'express'
+
+/**
+ * Returns a short reason when the request target cannot be routed safely, or
+ * null when it is fine. Only the path (before `?`) is inspected.
+ *
+ * Backslash and protocol-relative (`//`) paths are rejected because
+ * react-router's SSR `encodeLocation` calls `new URL()` on matched pathnames
+ * and throws `TypeError: Invalid URL` for those inputs.
+ */
+export function getMalformedRequestReason(
+	requestTarget: string,
+): string | null {
+	const path = requestTarget.split('?')[0] ?? ''
+
+	let decoded: string
+	try {
+		decoded = decodeURIComponent(path)
+	} catch {
+		return 'undecodable percent-encoding'
+	}
+
+	for (const char of decoded) {
+		const code = char.charCodeAt(0)
+		if (code <= 0x1f || code === 0x7f) {
+			return 'control characters in path'
+		}
+	}
+
+	if (decoded.includes('\\')) {
+		return 'backslash in path'
+	}
+
+	if (decoded.startsWith('//')) {
+		return 'protocol-relative path'
+	}
+
+	return null
+}
+
+export function rejectMalformedRequests(
+	req: Request,
+	res: Response,
+	next: NextFunction,
+) {
+	const reason = getMalformedRequestReason(req.url ?? '')
+	if (reason) {
+		res.status(400).type('text/plain').send(`Bad Request: ${reason}`)
+		return
+	}
+	next()
+}

--- a/packages/workshop-app/tests/catchall-route.test.ts
+++ b/packages/workshop-app/tests/catchall-route.test.ts
@@ -1,9 +1,45 @@
 import { expect, test } from 'vitest'
-import { action } from '../app/routes/$.tsx'
+import { action, loader } from '../app/routes/$.tsx'
 
 test('returns a plain 404 for scanner POSTs to catch-all paths', async () => {
 	const response = action()
 
 	expect(response.status).toBe(404)
 	await expect(response.text()).resolves.toBe('Not found')
+})
+
+function callLoader(splat: string | undefined) {
+	return loader({ params: { '*': splat } } as Parameters<typeof loader>[0])
+}
+
+test('404s when the first segment is empty because Number("") is 0 (aha: //.env%00 used to 500)', async () => {
+	await expect(callLoader('/.env\u0000')).rejects.toMatchObject({ status: 404 })
+})
+
+test('redirects a numeric exercise path to /exercise/...', async () => {
+	const response = await callLoader('1/1')
+	expect(response.status).toBe(302)
+	expect(response.headers.get('Location')).toBe('/exercise/1/1')
+})
+
+test('redirects a zero-padded exercise path including the step type', async () => {
+	const response = await callLoader('01/02/problem')
+	expect(response.status).toBe(302)
+	expect(response.headers.get('Location')).toBe('/exercise/01/02/problem')
+})
+
+test('404s a non-numeric first segment', async () => {
+	await expect(callLoader('foo/bar')).rejects.toMatchObject({ status: 404 })
+})
+
+test('404s a first segment with surrounding whitespace (Number would coerce)', async () => {
+	await expect(callLoader(' 1 /2')).rejects.toMatchObject({ status: 404 })
+})
+
+test('404s an empty splat', async () => {
+	await expect(callLoader('')).rejects.toMatchObject({ status: 404 })
+})
+
+test('404s when the splat param is missing', async () => {
+	await expect(callLoader(undefined)).rejects.toMatchObject({ status: 404 })
 })

--- a/packages/workshop-app/tests/launch-editor-input.test.ts
+++ b/packages/workshop-app/tests/launch-editor-input.test.ts
@@ -99,19 +99,3 @@ test('an unparseable launch form rejects with a 400 Response, not a ZodError (ah
 		submit({ appFile: 'src/index.ts', appName: 'playground' }),
 	).rejects.toMatchObject({ status: 400 })
 })
-
-test('the production payload that used to 500 now gets past validation (aha)', async () => {
-	// Whatever the outcome, it has to be an HTTP response rather than a raw
-	// ZodError escaping as an unhandled server fault.
-	await expect(
-		submit({
-			appFile: 'src/index.ts',
-			appName: 'playground',
-			column: '',
-			file: '',
-			line: 'false',
-			'show-progress-bar': 'true',
-			type: 'appFile',
-		}),
-	).rejects.toBeInstanceOf(Response)
-})

--- a/packages/workshop-app/tests/launch-editor-input.test.ts
+++ b/packages/workshop-app/tests/launch-editor-input.test.ts
@@ -1,0 +1,117 @@
+import { expect, test, vi } from 'vitest'
+
+vi.stubGlobal('ENV', { EPICSHOP_DEPLOYED: false })
+
+const { LaunchSchema, action } = await import('../app/routes/launch-editor.tsx')
+
+test('line "false" parses as undefined instead of NaN ZodError 500 (aha)', () => {
+	expect(
+		LaunchSchema.safeParse({
+			type: 'appFile',
+			appFile: ['src/index.ts'],
+			appName: 'playground',
+			file: '',
+			line: 'false',
+			column: '',
+		}),
+	).toEqual(
+		expect.objectContaining({
+			success: true,
+			data: expect.objectContaining({
+				line: undefined,
+				column: undefined,
+			}),
+		}),
+	)
+})
+
+test('empty line string is undefined, not coerced to 0 (aha)', () => {
+	expect(
+		LaunchSchema.safeParse({
+			type: 'appFile',
+			appFile: ['src/index.ts'],
+			appName: 'playground',
+			line: '',
+		}),
+	).toEqual(
+		expect.objectContaining({
+			success: true,
+			data: expect.objectContaining({ line: undefined }),
+		}),
+	)
+})
+
+test('numeric line string becomes a number', () => {
+	expect(
+		LaunchSchema.safeParse({
+			type: 'appFile',
+			appFile: ['src/index.ts'],
+			appName: 'playground',
+			line: '42',
+		}),
+	).toEqual(
+		expect.objectContaining({
+			success: true,
+			data: expect.objectContaining({ line: 42 }),
+		}),
+	)
+})
+
+test('non-numeric column is undefined, not a validation failure (aha)', () => {
+	expect(
+		LaunchSchema.safeParse({
+			type: 'appFile',
+			appFile: ['src/index.ts'],
+			appName: 'playground',
+			column: 'abc',
+		}),
+	).toEqual(
+		expect.objectContaining({
+			success: true,
+			data: expect.objectContaining({ column: undefined }),
+		}),
+	)
+})
+
+test('missing type still fails validation so junk cursor hints did not open the schema', () => {
+	expect(
+		LaunchSchema.safeParse({
+			appFile: ['src/index.ts'],
+			appName: 'playground',
+			line: 'false',
+		}).success,
+	).toBe(false)
+})
+
+function submit(fields: Record<string, string>) {
+	const request = new Request('http://localhost/launch-editor', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams(fields),
+	})
+	return action({ request, params: {}, context: {} } as Parameters<
+		typeof action
+	>[0])
+}
+
+test('an unparseable launch form rejects with a 400 Response, not a ZodError (aha)', async () => {
+	await expect(
+		submit({ appFile: 'src/index.ts', appName: 'playground' }),
+	).rejects.toMatchObject({ status: 400 })
+})
+
+test('the production payload that used to 500 now gets past validation (aha)', async () => {
+	// Whatever the outcome, it has to be an HTTP response rather than a raw
+	// ZodError escaping as an unhandled server fault.
+	await expect(
+		submit({
+			appFile: 'src/index.ts',
+			appName: 'playground',
+			column: '',
+			file: '',
+			line: 'false',
+			'show-progress-bar': 'true',
+			type: 'appFile',
+		}),
+	).rejects.toBeInstanceOf(Response)
+})

--- a/packages/workshop-app/tests/lookout-route.test.ts
+++ b/packages/workshop-app/tests/lookout-route.test.ts
@@ -1,0 +1,15 @@
+import { expect, test, vi } from 'vitest'
+
+test('returns 405 for GET because a resource route with no loader makes React Router report an internal server error (aha)', async () => {
+	// lookout.ts reads ENV.SENTRY_DSN at module scope, so stub before importing.
+	vi.stubGlobal('ENV', {
+		SENTRY_DSN: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+		SENTRY_PROJECT_ID: '0',
+	})
+	const { loader } = await import('../app/routes/resources+/lookout.ts')
+
+	const response = loader()
+
+	expect(response.status).toBe(405)
+	expect(response.headers.get('Allow')).toBe('POST')
+})

--- a/packages/workshop-app/tests/lookout-route.test.ts
+++ b/packages/workshop-app/tests/lookout-route.test.ts
@@ -1,15 +1,28 @@
 import { expect, test, vi } from 'vitest'
 
-test('returns 405 for GET because a resource route with no loader makes React Router report an internal server error (aha)', async () => {
-	// lookout.ts reads ENV.SENTRY_DSN at module scope, so stub before importing.
-	vi.stubGlobal('ENV', {
-		SENTRY_DSN: 'https://examplePublicKey@o0.ingest.sentry.io/0',
-		SENTRY_PROJECT_ID: '0',
-	})
-	const { loader } = await import('../app/routes/resources+/lookout.ts')
+// lookout.ts reads ENV.SENTRY_DSN at module scope, so stub before importing.
+vi.stubGlobal('ENV', {
+	SENTRY_DSN: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+	SENTRY_PROJECT_ID: '0',
+})
+const { action, loader } = await import('../app/routes/resources+/lookout.ts')
 
+test('returns 405 for GET because a resource route with no loader makes React Router report an internal server error (aha)', () => {
 	const response = loader()
 
 	expect(response.status).toBe(405)
 	expect(response.headers.get('Allow')).toBe('POST')
+})
+
+test('rejects a body that is not a Sentry envelope with a 400, not a JSON.parse 500 (aha)', async () => {
+	const request = new Request('http://localhost/resources/lookout', {
+		method: 'POST',
+		body: 'not an envelope',
+	})
+
+	await expect(
+		action({ request, params: {}, context: {} } as Parameters<
+			typeof action
+		>[0]),
+	).rejects.toMatchObject({ status: 400 })
 })

--- a/packages/workshop-app/tests/malformed-request.test.ts
+++ b/packages/workshop-app/tests/malformed-request.test.ts
@@ -1,6 +1,7 @@
 import { type Request, type Response } from 'express'
 import { expect, test, vi } from 'vitest'
 import {
+	decodeRequestTarget,
 	getMalformedRequestReason,
 	rejectMalformedRequests,
 } from '../server/malformed-request.ts'
@@ -89,4 +90,12 @@ test('the middleware answers a malformed target with a 400 and stops the chain',
 
 test('the middleware passes a routable target straight through untouched', () => {
 	expect(callMiddleware('/exercise/01/01/problem')).toEqual({ nextCalls: 1 })
+})
+
+test('an undecodable target logs as-is because throwing here killed the process (aha)', () => {
+	expect(decodeRequestTarget('/%zz')).toBe('/%zz')
+})
+
+test('a decodable target is still decoded for the log', () => {
+	expect(decodeRequestTarget('/exercise/a%20b')).toBe('/exercise/a b')
 })

--- a/packages/workshop-app/tests/malformed-request.test.ts
+++ b/packages/workshop-app/tests/malformed-request.test.ts
@@ -1,0 +1,92 @@
+import { type Request, type Response } from 'express'
+import { expect, test, vi } from 'vitest'
+import {
+	getMalformedRequestReason,
+	rejectMalformedRequests,
+} from '../server/malformed-request.ts'
+
+test('rejects /%5C because react-router decodes it to a backslash and encodeLocation new URL throws during SSR (aha)', () => {
+	expect(getMalformedRequestReason('/%5C')).toBe('backslash in path')
+})
+
+test('rejects //.env%00 because decoded path has a NUL that cannot go in a header (aha)', () => {
+	expect(getMalformedRequestReason('//.env%00')).toBe(
+		'control characters in path',
+	)
+})
+
+test('rejects /.env%0d%0a because CR/LF in the path enable header injection (aha)', () => {
+	expect(getMalformedRequestReason('/.env%0d%0a')).toBe(
+		'control characters in path',
+	)
+})
+
+test('rejects //foo because react-router treats protocol-relative paths as absolute URLs and new URL throws (aha)', () => {
+	expect(getMalformedRequestReason('//foo')).toBe('protocol-relative path')
+})
+
+test('rejects /%zz because decodeURIComponent throws URIError (aha)', () => {
+	expect(getMalformedRequestReason('/%zz')).toBe('undecodable percent-encoding')
+})
+
+test('accepts the root path', () => {
+	expect(getMalformedRequestReason('/')).toBeNull()
+})
+
+test('accepts a normal exercise path', () => {
+	expect(getMalformedRequestReason('/exercise/01/01/problem')).toBeNull()
+})
+
+test('accepts a playground API path', () => {
+	expect(
+		getMalformedRequestReason('/app/playground/api/create-ship'),
+	).toBeNull()
+})
+
+test('accepts a resources lookout path', () => {
+	expect(getMalformedRequestReason('/resources/lookout')).toBeNull()
+})
+
+test('accepts a path with a legit encoded space', () => {
+	expect(getMalformedRequestReason('/a%20b')).toBeNull()
+})
+
+test('accepts query strings that contain // and %5C because only the path is inspected (aha)', () => {
+	expect(getMalformedRequestReason('/search?q=a%5Cb&next=//x')).toBeNull()
+})
+
+function callMiddleware(url: string) {
+	const sent: { status?: number; type?: string; body?: string } = {}
+	const res = {
+		status(code: number) {
+			sent.status = code
+			return res
+		},
+		type(value: string) {
+			sent.type = value
+			return res
+		},
+		send(body: string) {
+			sent.body = body
+			return res
+		},
+	}
+	const next = vi.fn()
+
+	rejectMalformedRequests({ url } as Request, res as unknown as Response, next)
+
+	return { ...sent, nextCalls: next.mock.calls.length }
+}
+
+test('the middleware answers a malformed target with a 400 and stops the chain', () => {
+	expect(callMiddleware('/%5C')).toEqual({
+		status: 400,
+		type: 'text/plain',
+		body: 'Bad Request: backslash in path',
+		nextCalls: 0,
+	})
+})
+
+test('the middleware passes a routable target straight through untouched', () => {
+	expect(callMiddleware('/exercise/01/01/problem')).toEqual({ nextCalls: 1 })
+})

--- a/packages/workshop-app/tests/route-errors.test.ts
+++ b/packages/workshop-app/tests/route-errors.test.ts
@@ -1,0 +1,67 @@
+import {
+	isRouteErrorResponse,
+	UNSAFE_ErrorResponseImpl as ErrorResponseImpl,
+} from 'react-router'
+import { expect, test } from 'vitest'
+import { isClientErrorResponse } from '../app/utils/route-errors.ts'
+
+test('treats a 405 route error response as a client error (react-router answers it with a 405, so it is not a server fault)', () => {
+	const error = new ErrorResponseImpl(
+		405,
+		'Method Not Allowed',
+		new Error(
+			'You made a POST request to "/" but did not provide an `action` for route "root", so there is no way to handle the request.',
+		),
+		true,
+	)
+
+	expect(isRouteErrorResponse(error)).toBe(true)
+	expect(isClientErrorResponse(error)).toBe(true)
+})
+
+test('treats a 404 route error response as a client error (react-router answers it with a 404, so it is not a server fault)', () => {
+	const error = new ErrorResponseImpl(
+		404,
+		'Not Found',
+		new Error('No route matches URL "/.env%0d%0a"'),
+		true,
+	)
+
+	expect(isRouteErrorResponse(error)).toBe(true)
+	expect(isClientErrorResponse(error)).toBe(true)
+})
+
+test('treats a 400 route error response as a client error (react-router answers it with a 400, so it is not a server fault)', () => {
+	const error = new ErrorResponseImpl(
+		400,
+		'Bad Request',
+		new Error(
+			'You made a GET request to "/resource" but did not provide a `loader` for route "resource", so there is no way to handle the request.',
+		),
+		true,
+	)
+
+	expect(isRouteErrorResponse(error)).toBe(true)
+	expect(isClientErrorResponse(error)).toBe(true)
+})
+
+test('does not treat a 500 route error response as a client error (server faults must keep reporting)', () => {
+	const error = new ErrorResponseImpl(
+		500,
+		'Internal Server Error',
+		new Error('boom'),
+		true,
+	)
+
+	expect(isRouteErrorResponse(error)).toBe(true)
+	expect(isClientErrorResponse(error)).toBe(false)
+})
+
+test('does not treat a plain Error as a client error response', () => {
+	expect(isClientErrorResponse(new Error('boom'))).toBe(false)
+})
+
+test('does not treat null or undefined as a client error response', () => {
+	expect(isClientErrorResponse(null)).toBe(false)
+	expect(isClientErrorResponse(undefined)).toBe(false)
+})

--- a/packages/workshop-app/vitest.sentry-noise.config.ts
+++ b/packages/workshop-app/vitest.sentry-noise.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
 	test: {
 		name: 'app-sentry-noise',
-		include: ['tests/catchall-route.test.ts', 'tests/sentry-filters.test.ts'],
+		include: ['tests/*.test.ts'],
 		setupFiles: ['../../tests/vitest-setup.ts'],
 		mockReset: true,
 	},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of a Sentry cleanup pass over the `epicshop` project. Everything here is in the app server request pipeline. Eight independent bugs, each its own commit.

Together these account for **~12,400 events / ~1,150 affected users** over the last 90 days — the largest cluster in the whole Sentry org — plus one process-killing bug that testing turned up along the way.

![Before/after HTTP status for every request target under test, measured against a running dev server](https://cursor.com/artifacts/c/art-335f6710-2dd1-4296-a6d0-df69d63d41cb)

## One thing to check before merging

`server/malformed-request.ts` rejects any request path containing a backslash. That is what fixes the `Invalid URL` crash, but it is a blanket rule over every request, including `/app/:appName/*` which serves files out of a learner's exercise app. On Windows, `path.join(appDir, 'foo\\bar.js')` currently resolves and serves the file, so a workshop whose content emitted `src="foo\bar.js"` would go from working to a 400.

I audited this repo and found no code path that puts a filesystem separator into a local URL — `getAppName` swaps `path.sep` for `__sep__`, `files.ts` normalizes globby output, and the `safePath` helpers only touch external GitHub links. Windows CI passes. But I can't see the ~30 workshop repos that install this package, so I've left the merge call to you rather than guessing on their behalf. Everything else here I'd merge without hesitation.

## What was wrong

**1. React Router's own client 4xx responses were reported as server exceptions** (`app/entry.server.tsx`, new `app/utils/route-errors.ts`)

`getInternalRouterError` builds an `ErrorResponse` carrying a real `Error`, so React Router forwards it to the server `handleError` hook even though it has *already answered the request* with the correct 4xx status. A `POST /` to a route with no `action`, a `GET` to a route with no `loader`, and an unmatched URL are all client mistakes.

The 405 alone is **11,267 events across 922 users**, almost entirely scanners probing deployed workshops for Next.js server actions (they arrive with a `Next-Action` header and a spoofed Chrome user agent, so the existing `isbot` check misses them). 5xx keeps reporting.

**2. A malformed request URL crashed the whole server process** (`server/index.ts`)

Found while testing this branch, not from Sentry — because the process dies before it can report. The morgan `url` token called `decodeURIComponent` on the raw request URL, so `GET /%zz` threw a `URIError` from inside morgan's `on-finished` listener. That is an uncaught exception: the server and every sidecar process went down. One request is enough.

```
Malformed URI sequence in request URL: /%zz
closing sidecar EpicMeApp
URIError: URI malformed
    at decodeURIComponent (<anonymous>)
    at morgan.url (packages/workshop-app/server/index.ts)
    at listener (node_modules/morgan/node_modules/on-finished/index.js:169:15)
```

**3. Unroutable request targets crashed instead of returning 400** (new `server/malformed-request.ts`)

Two production `TypeError`s came from paths that can never match a route:

- `GET /%5C` → React Router decodes the path to `/\`, then re-encodes match pathnames through `encodeLocation`, which calls `new URL('/\\', base)` → `TypeError: Invalid URL` (66 events / 60 users). A path starting with `//` hits the same function's `ABSOLUTE_URL_REGEX` branch and throws for the same reason.
- `GET //.env%00` → a NUL byte in the path, which cannot go into a header value.

A small Express middleware now refuses four cases before anything else sees them — undecodable percent-encoding, control characters, backslashes, and protocol-relative paths — with a plain 400.

**4. `Number('')` is `0`, so `//anything` wrongly redirected** (`app/routes/$.tsx`)

The catch-all's `!isNaN(Number(segments[0]))` check treated an *empty* first segment as an exercise number. `//.env%00` became a redirect to `/exercise//.env%00`, and building that `Location` header threw `TypeError: Headers.append: "/exercise//.env\u0000" is an invalid header value.` Now only a bare run of digits redirects, which also stops `Number` accepting ` 1 `, `0x10`, `1e3` and `Infinity`.

**5. `GET /resources/lookout` produced an internal error** (`app/routes/resources+/lookout.ts`)

The Sentry tunnel route only exported an `action`. Ordinary browser navigations to the URL (`Sec-Fetch-Mode: navigate`) produced React Router's "did not provide a `loader`" internal error — **907 events / 115 users**. It now returns a 405 with `Allow: POST`.

**6. A non-envelope body on the Sentry tunnel was a 500** (`app/routes/resources+/lookout.ts`)

`JSON.parse` on the first line of the body threw a `SyntaxError` for anything that wasn't a Sentry envelope. Also found while testing.

**7. `launch-editor` threw a raw `ZodError`** (`app/routes/launch-editor.tsx`)

Throwing the `ZodError` itself made bad client input an unhandled server fault. Every other validation failure in that same action already throws a 400 `Response`. Separately, `line`/`column` went through `z.coerce.number()`, so an empty value silently became line 0 and a stray `"false"` became a request-failing `NaN`. They're optional cursor hints, so junk now means "no hint".

**8. Learner exercise bugs looked like epicshop crashes** (`app/routes/_app+/app.$appName+/api.$.ts`)

`/app/:appName/api/*` proxies to the learner's own `api.server.ts`. That module is imported from a `data:` URL, so when it throws there are no app frames in the stack and it is indistinguishable from an epicshop fault. The reported case was a learner calling `request.formData()` on a `text/plain` body (**124 events / 24 users**). The failure is now returned as a response and logged to the learner's terminal, where they can actually act on it — a thrown `Response` is handed back verbatim without running `handleError`.

## Verification

- Every request target above was replayed with `curl --path-as-is` against a running dev server, before and after. Results in the table at the top.
- The server process now survives the full probe suite; before this branch, `GET /%zz` killed it.
- Temporary instrumentation in `handleError` confirmed the wiring end to end: the `POST /` 405 arrives and is skipped (`skipped: true`), while a genuine `TypeError` from a loader still goes through to reporting (`skipped: false`). The instrumentation was removed before committing.
- Full `npm run validate` gate green (build, typecheck, lint, test), and CI green on ubuntu, macOS and Windows.
- 40 node tests in the `app-sentry-noise` vitest project, up from 2. `include` widened to `tests/*.test.ts` so future ones are picked up automatically.

## Deliberately not fixed here

- `Error: Bad Request` from `singleFetchAction` (54 events / 4 users) is React Router's cross-origin submission check firing in GitHub Codespaces, where the port-forwarding proxy rewrites `Origin` to `localhost:5639` while setting `X-Forwarded-Host` to the public `*.app.github.dev` host. React Router prefers `X-Forwarded-Host`, so they never match. Fixing it means configuring `allowedActionOrigins` (which is build-time config, so it can't be conditioned on whether an install is deployed) or normalizing proxy headers — that is CSRF surface and wants a deliberate decision, not a drive-by.
- `Error: EPERM: operation not permitted, open` (34 events / 3 users, Windows only) arrives with no stack frames and looks like local file locking on the learner's machine.
- `Error: Unexpected Server Error` (401 events / 24 users) is the client-side mirror of these server 500s — its latest event shares a timestamp to the second with the `singleFetchAction` one. It should decay as the server-side causes above are fixed.

Each of the eleven Sentry issues has a comment with its root cause and requested status.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ff04fcd-9686-43dc-8c4c-e3ee9afe75ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ff04fcd-9686-43dc-8c4c-e3ee9afe75ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

