### PR TITLE
fix: recover Fly workshop deploys after 6.90.17 boot failure

### DIFF
--- a/.github/workflows/update-workshops.yml
+++ b/.github/workflows/update-workshops.yml
@@ -10,7 +10,8 @@ jobs:
   update-workshops:
     name: 🔄 Update Workshop Repos
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Staggered pushes avoid Fly deploy stampedes; 34 workshops * ~90s needs headroom.
+    timeout-minutes: 120
     permissions:
       contents: write
       actions: read

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,6 +30,14 @@ If a mass update still leaves apps unhealthy, re-run each workshop's `deploy`
 workflow sequentially (or with low concurrency) via `workflow_dispatch` rather
 than pushing another thundering herd.
 
+### 6.90.17 boot failure note
+
+`@epic-web/workshop-app@6.90.17` imported `sentry-server-filters.js` from
+`instrument.js` without publishing that file. Fly apps with `SENTRY_DSN` set
+crashed on boot. Deployed `epicshop start` also failed to propagate the child
+exit code (exited 0), so Fly's `on-failure` restart policy did not recover the
+machine. Fixed in a later patch release; do not leave workshops on `6.90.17`.
+
 ## Presence App Deployment
 
 The workshop-presence app is deployed to PartyKit/Cloudflare using a GitHub

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,6 +7,29 @@ This will also reference the `package.json` value for `epicshop.githubRoot` as
 the root for all links to files so `<InlineFile />` and `<LaunchEditor />` will
 open the files on GitHub instead of on your local machine.
 
+## Mass workshop updates and Fly deploys
+
+The `Update Workshops` workflow pushes version bumps across many `epicweb-dev/*`
+workshop repos. Each push triggers that workshop's `deploy` workflow, which runs
+`flyctl deploy`.
+
+To avoid Fly machine-lease contention and health-check API timeouts during that
+fan-out:
+
+- `other/update-workshops` staggers git pushes (default 90s) while still doing
+  clone/install work concurrently
+- It syncs a canonical deploy workflow
+  (`other/update-workshops/canonical/deploy.yml`) into each workshop's
+  `.github/workflows/validate.yml`, including deploy retries and a post-deploy
+  HTTP health probe (so a stopped scale-to-zero machine is not treated as
+  success)
+- It lengthens `epicshop/fly.yaml` HTTP/TCP health-check grace periods when
+  present
+
+If a mass update still leaves apps unhealthy, re-run each workshop's `deploy`
+workflow sequentially (or with low concurrency) via `workflow_dispatch` rather
+than pushing another thundering herd.
+
 ## Presence App Deployment
 
 The workshop-presence app is deployed to PartyKit/Cloudflare using a GitHub

--- a/other/update-workshops/canonical/deploy.yml
+++ b/other/update-workshops/canonical/deploy.yml
@@ -69,10 +69,12 @@ jobs:
     # Retries + Fly health waits need headroom beyond a single deploy attempt.
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    # only deploy main branch on pushes on non-forks
+    # Deploy main on push or manual dispatch (non-forks). Dispatch is needed for
+    # sequenced recovery / re-deploys without inventing empty commits.
     if:
-      ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' &&
-      github.repository_owner == 'epicweb-dev' }}
+      ${{ github.ref == 'refs/heads/main' && github.repository_owner ==
+      'epicweb-dev' && (github.event_name == 'push' || github.event_name ==
+      'workflow_dispatch') }}
 
     steps:
       - name: ⬇️ Checkout repo
@@ -95,7 +97,18 @@ jobs:
           max_attempts=4
           delay_seconds=45
           attempt=1
-          app_name="$(awk -F"'" '/^app:/{print $2; exit}' fly.yaml)"
+          # Support both `app: my-app` and `app: 'my-app'` / `app: "my-app"`.
+          app_name="$(
+            awk '
+              /^app:[[:space:]]*/ {
+                value = $0
+                sub(/^app:[[:space:]]*/, "", value)
+                gsub(/^['\''"]|['\''"]$/, "", value)
+                print value
+                exit
+              }
+            ' fly.yaml
+          )"
           if [ -z "$app_name" ]; then
             echo "Could not parse app name from fly.yaml" >&2
             exit 1

--- a/other/update-workshops/canonical/deploy.yml
+++ b/other/update-workshops/canonical/deploy.yml
@@ -1,0 +1,152 @@
+name: deploy
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+  pull_request: {}
+
+jobs:
+  setup:
+    name: 🔧 Setup
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
+
+      - name: ▶️ Add repo
+        run: |
+          npx --yes epicshop@latest add ${{ github.event.repository.name }}#${{ github.head_ref || github.ref_name }} ./workshop
+        env:
+          # Kept getting npm ECOMPROMISED errors on windows. This fixed it.
+          npm_config_cache: ${{ runner.temp }}/npm-cache
+          SKIP_PLAYWRIGHT: true
+
+      - name: ʦ TypeScript
+        run: npm run typecheck
+        working-directory: ./workshop
+
+      - name: ⬣ Oxlint
+        run: npm run lint
+        working-directory: ./workshop
+
+  tests:
+    name: 🧪 Test
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    # Use continue-on-error to ensure this job doesn't fail the workflow
+    continue-on-error: true
+
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: 🧪 Run tests
+        id: run_tests
+        run: node ./epicshop/test.ts ..s
+
+  deploy:
+    name: 🚀 Deploy
+    # Retries + Fly health waits need headroom beyond a single deploy attempt.
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    # only deploy main branch on pushes on non-forks
+    if:
+      ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' &&
+      github.repository_owner == 'epicweb-dev' }}
+
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: 🎈 Setup Fly
+        uses: superfly/flyctl-actions/setup-flyctl@1.5
+
+      - name: 🚀 Deploy
+        working-directory: ./epicshop
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Mass epicshop updates can fan out dozens of Fly deploys at once.
+          # Fly lease contention and machines API health-check waits then flake.
+          # Retry with exponential backoff so a single thundering-herd event does
+          # not leave workshop apps stranded on a failed rolling update.
+          max_attempts=4
+          delay_seconds=45
+          attempt=1
+          app_name="$(awk -F"'" '/^app:/{print $2; exit}' fly.yaml)"
+          if [ -z "$app_name" ]; then
+            echo "Could not parse app name from fly.yaml" >&2
+            exit 1
+          fi
+
+          while true; do
+            echo "::group::flyctl deploy attempt ${attempt}/${max_attempts}"
+            set +e
+            flyctl deploy --remote-only \
+              --build-arg EPICSHOP_GITHUB_REPO=https://github.com/${{ github.repository }} \
+              --build-arg EPICSHOP_COMMIT_SHA=${{ github.sha }}
+            status=$?
+            set -e
+            echo "::endgroup::"
+
+            if [ "$status" -eq 0 ]; then
+              # flyctl can treat a stopped scale-to-zero machine as "good" without
+              # ever proving the new image boots. Wake the app and require health.
+              echo "::group::post-deploy health check for ${app_name}"
+              healthy=0
+              for probe in 1 2 3 4 5 6 7 8 9 10; do
+                set +e
+                code="$(curl -sS -o /tmp/epicshop-health -w '%{http_code}' --max-time 30 \
+                  "https://${app_name}.fly.dev/resources/healthcheck")"
+                curl_status=$?
+                set -e
+                body="$(tr -d '\n' </tmp/epicshop-health | head -c 80)"
+                echo "probe ${probe}: curl_exit=${curl_status} http=${code} body=${body}"
+                if [ "$curl_status" -eq 0 ] && [ "$code" = "200" ]; then
+                  healthy=1
+                  break
+                fi
+                sleep 15
+              done
+              echo "::endgroup::"
+
+              if [ "$healthy" -eq 1 ]; then
+                exit 0
+              fi
+
+              echo "Deploy reported success but app failed post-deploy health checks" >&2
+              status=1
+            fi
+
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "flyctl deploy failed after ${max_attempts} attempts" >&2
+              exit "$status"
+            fi
+
+            echo "Deploy attempt ${attempt} failed (exit ${status}); retrying in ${delay_seconds}s..."
+            sleep "$delay_seconds"
+            delay_seconds=$((delay_seconds * 2))
+            attempt=$((attempt + 1))
+          done

--- a/other/update-workshops/index.js
+++ b/other/update-workshops/index.js
@@ -14,9 +14,49 @@ const GITHUB_ORG = 'epicweb-dev'
 const GITHUB_TOKEN =
 	process.env.WORKSHOP_UPDATE_TOKEN ?? process.env.GITHUB_TOKEN
 const USING_WORKSHOP_UPDATE_TOKEN = Boolean(process.env.WORKSHOP_UPDATE_TOKEN)
+// Keep clone/install work parallel, but serialize git pushes so workshop deploy
+// workflows do not stampede Fly leases / machines API health checks.
 const CONCURRENCY = 5
+const PUSH_STAGGER_MS = Number(process.env.PUSH_STAGGER_MS || 90_000)
 const TARGET_NODE_VERSION = '26.0.0'
 const ADDITIONAL_WORKSHOP_REPOS = ['ai-powered-apps', 'workshop-template']
+const CANONICAL_DEPLOY_WORKFLOW = path.join(
+	__dirname,
+	'canonical',
+	'deploy.yml',
+)
+const DEPLOY_WORKFLOW_PATH = '.github/workflows/validate.yml'
+const FLY_CONFIG_PATH = 'epicshop/fly.yaml'
+
+let lastPushAt = 0
+let pushChain = Promise.resolve()
+
+function delay(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function withPushStagger(fn) {
+	const run = pushChain.then(async () => {
+		const waitMs = Math.max(0, PUSH_STAGGER_MS - (Date.now() - lastPushAt))
+		if (waitMs > 0) {
+			console.log(
+				`⏳ Staggering push by ${Math.round(waitMs / 1000)}s to avoid Fly deploy stampedes`,
+			)
+			await delay(waitMs)
+		}
+		try {
+			return await fn()
+		} finally {
+			lastPushAt = Date.now()
+		}
+	})
+	// Keep the chain alive even if one push fails.
+	pushChain = run.then(
+		() => {},
+		() => {},
+	)
+	return run
+}
 
 if (!GITHUB_TOKEN) {
 	console.error(
@@ -185,7 +225,6 @@ async function verifyPackageAvailability(
 	version,
 	maxRetries = 20,
 ) {
-	const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 	// For scoped packages like @epic-web/workshop-app, extract just the package name part
 	const tarballName = packageName.includes('/')
 		? packageName.split('/')[1]
@@ -263,6 +302,97 @@ async function pullRebaseWithFallback(cwd) {
 }
 
 /**
+ * Keep workshop deploy workflows aligned with the retrying canonical template.
+ */
+async function syncDeployWorkflow(workshopDir) {
+	const targetPath = path.join(workshopDir, DEPLOY_WORKFLOW_PATH)
+	const canonical = await fs.readFile(CANONICAL_DEPLOY_WORKFLOW, 'utf8')
+	let current = null
+	try {
+		current = await fs.readFile(targetPath, 'utf8')
+	} catch (error) {
+		if (error?.code !== 'ENOENT') throw error
+	}
+
+	if (current === canonical) {
+		return { changed: false, path: DEPLOY_WORKFLOW_PATH }
+	}
+
+	await fs.mkdir(path.dirname(targetPath), { recursive: true })
+	await fs.writeFile(targetPath, canonical, 'utf8')
+	return { changed: true, path: DEPLOY_WORKFLOW_PATH }
+}
+
+/**
+ * Lengthen Fly health-check grace periods so cold boots are not raced.
+ * App names differ per workshop, so patch in place instead of overwriting.
+ */
+async function patchFlyHealthGracePeriods(workshopDir) {
+	const flyPath = path.join(workshopDir, FLY_CONFIG_PATH)
+	let contents
+	try {
+		contents = await fs.readFile(flyPath, 'utf8')
+	} catch (error) {
+		if (error?.code === 'ENOENT') {
+			return { changed: false, path: FLY_CONFIG_PATH, missing: true }
+		}
+		throw error
+	}
+
+	let section = null
+	let httpChecks = 0
+	let tcpChecks = 0
+	const next = contents
+		.split('\n')
+		.map((line) => {
+			const trimmed = line.trim()
+			if (trimmed === 'http_checks:') {
+				section = 'http'
+				return line
+			}
+			if (trimmed === 'tcp_checks:') {
+				section = 'tcp'
+				return line
+			}
+			// Leave the current checks block when indentation returns to the
+			// services list / top-level keys.
+			if (
+				section &&
+				trimmed &&
+				!line.startsWith(' ') &&
+				!line.startsWith('\t')
+			) {
+				section = null
+			} else if (
+				section &&
+				/^[A-Za-z_][\w-]*:\s*$/.test(trimmed) &&
+				!trimmed.endsWith('checks:')
+			) {
+				const indent = line.match(/^\s*/)?.[0].length ?? 0
+				if (indent <= 4) section = null
+			}
+
+			if (section && /^\s*grace_period:\s*\S+\s*$/.test(line)) {
+				if (section === 'http') {
+					httpChecks += 1
+					return line.replace(/grace_period:\s*\S+/, 'grace_period: 60s')
+				}
+				tcpChecks += 1
+				return line.replace(/grace_period:\s*\S+/, 'grace_period: 30s')
+			}
+			return line
+		})
+		.join('\n')
+
+	if (next === contents) {
+		return { changed: false, path: FLY_CONFIG_PATH, httpChecks, tcpChecks }
+	}
+
+	await fs.writeFile(flyPath, next, 'utf8')
+	return { changed: true, path: FLY_CONFIG_PATH, httpChecks, tcpChecks }
+}
+
+/**
  * Update package.json files - only root and epicshop/package.json
  */
 async function updatePackageJsonFiles(workshopDir, version) {
@@ -331,10 +461,18 @@ async function updateWorkshopRepo(repo, version) {
 		)
 
 		// Configure sparse checkout in non-cone mode to allow file-level patterns
-		// This lets us checkout only specific files (like package.json) from workspace dirs
+		// This lets us checkout only specific files (like package.json) from workspace dirs.
+		// Include deploy workflow + fly config so mass updates can harden them too.
 		await execa(
 			'git',
-			['sparse-checkout', 'set', '--no-cone', '/*', 'epicshop/'],
+			[
+				'sparse-checkout',
+				'set',
+				'--no-cone',
+				'/*',
+				'epicshop/',
+				'.github/workflows/',
+			],
 			{ cwd: tempDir, env: getGitEnv() },
 		)
 
@@ -352,7 +490,21 @@ async function updateWorkshopRepo(repo, version) {
 			version,
 		)
 
-		if (!changed) {
+		console.log(
+			`🛠️  ${repoName} - syncing deploy workflow and Fly health grace`,
+		)
+		const workflowSync = await syncDeployWorkflow(tempDir)
+		const flyPatch = await patchFlyHealthGracePeriods(tempDir)
+		if (workflowSync.changed) {
+			console.log(`🛠️  ${repoName} - updated ${workflowSync.path}`)
+		}
+		if (flyPatch.changed) {
+			console.log(
+				`🛠️  ${repoName} - updated ${flyPatch.path} health grace periods`,
+			)
+		}
+
+		if (!changed && !workflowSync.changed && !flyPatch.changed) {
 			console.log(`🟢 ${repoName} - already up to date`)
 			return { repo: repoName, status: 'up-to-date' }
 		}
@@ -457,7 +609,7 @@ async function updateWorkshopRepo(repo, version) {
 			}
 		}
 
-		// Only stage the 4 files we're tracking
+		// Stage package files, deploy workflow, and fly config when present.
 		const filesToStage = []
 		for (const pkg of pkgs) {
 			const pkgPath = path.join(tempDir, pkg)
@@ -505,6 +657,8 @@ async function updateWorkshopRepo(repo, version) {
 				// File doesn't exist, skip
 			}
 		}
+		if (workflowSync.changed) filesToStage.push(DEPLOY_WORKFLOW_PATH)
+		if (flyPatch.changed) filesToStage.push(FLY_CONFIG_PATH)
 
 		// Some workshop repos gitignore files we'd otherwise stage (e.g.
 		// epicshop/package-lock.json) and `git add` fails on ignored files.
@@ -545,27 +699,34 @@ async function updateWorkshopRepo(repo, version) {
 			return { repo: repoName, status: 'no-changes' }
 		}
 
+		const commitMessage = changed
+			? 'chore: update epicshop'
+			: 'chore: harden fly deploy workflow'
+
 		// Commit changes
 		console.log(`💾 ${repoName} - committing changes`)
-		await execa('git', ['commit', '-m', 'chore: update epicshop'], {
+		await execa('git', ['commit', '-m', commitMessage], {
 			cwd: tempDir,
 			env: getGitEnv(),
 		})
 
-		// Push changes (retry once with a pull/rebase if needed)
-		console.log(`⬆️  ${repoName} - pushing changes`)
-		try {
-			await execa('git', ['push'], {
-				cwd: tempDir,
-				env: getGitEnv(),
-			})
-		} catch {
-			await pullRebaseWithFallback(tempDir)
-			await execa('git', ['push'], {
-				cwd: tempDir,
-				env: getGitEnv(),
-			})
-		}
+		// Push changes (retry once with a pull/rebase if needed), staggered so
+		// the resulting deploy workflows do not all hit Fly at once.
+		await withPushStagger(async () => {
+			console.log(`⬆️  ${repoName} - pushing changes`)
+			try {
+				await execa('git', ['push'], {
+					cwd: tempDir,
+					env: getGitEnv(),
+				})
+			} catch {
+				await pullRebaseWithFallback(tempDir)
+				await execa('git', ['push'], {
+					cwd: tempDir,
+					env: getGitEnv(),
+				})
+			}
+		})
 
 		console.log(`✅ ${repoName} - updated successfully`)
 		return { repo: repoName, status: 'updated' }
@@ -651,7 +812,7 @@ async function main() {
 		}
 
 		console.log(
-			`\n🚀 Processing ${workshops.length} repos with concurrency ${CONCURRENCY}\n`,
+			`\n🚀 Processing ${workshops.length} repos with concurrency ${CONCURRENCY} (push stagger ${Math.round(PUSH_STAGGER_MS / 1000)}s)\n`,
 		)
 
 		// Process repos in parallel with a simple concurrency pool (no extra deps)

--- a/packages/workshop-app/package.json
+++ b/packages/workshop-app/package.json
@@ -10,6 +10,8 @@
     "dist",
     "start.js",
     "instrument.js",
+    "sentry-server-filters.js",
+    "sentry-server-filters.d.ts",
     "patches"
   ],
   "type": "module",

--- a/packages/workshop-app/tests/published-files.test.ts
+++ b/packages/workshop-app/tests/published-files.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+
+const packageRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	'..',
+)
+const packageJson = JSON.parse(
+	readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),
+) as { files: Array<string> }
+
+test('npm package files include sentry-server-filters used by instrument.js (aha)', () => {
+	const instrument = readFileSync(
+		path.join(packageRoot, 'instrument.js'),
+		'utf8',
+	)
+	const relativeImports = [
+		...instrument.matchAll(/from\s+['"](\.\/[^'"]+)['"]/g),
+	].map((match) => match[1]!.replace(/^\.\//, ''))
+
+	expect(relativeImports.length).toBeGreaterThan(0)
+	for (const relativeImport of relativeImports) {
+		expect(
+			packageJson.files,
+			`${relativeImport} is imported by instrument.js and must be published`,
+		).toEqual(expect.arrayContaining([relativeImport]))
+	}
+})

--- a/packages/workshop-cli/src/commands/start.test.ts
+++ b/packages/workshop-cli/src/commands/start.test.ts
@@ -17,6 +17,50 @@ const repoRoot = path.resolve(__dirname, '..', '..', '..', '..')
 const testIf = process.platform === 'win32' ? test.skip : test
 
 testIf(
+	'deployed start propagates child exit code when parent has no HTTP server (aha)',
+	async () => {
+		await using fixture = await createDeployedCrashFixture()
+		const child = spawn(process.execPath, [fixture.runnerPath], {
+			cwd: repoRoot,
+			env: {
+				...process.env,
+				EPICSHOP_APP_LOCATION: fixture.appDir,
+				EPICSHOP_CONTEXT_CWD: fixture.workshopDir,
+				EPICSHOP_DEPLOYED: 'true',
+				EPICSHOP_IS_PUBLISHED: 'true',
+				NODE_ENV: 'production',
+				// Ensure published Sentry preload is not engaged for this crash test.
+				SENTRY_DSN: '',
+			},
+			stdio: ['ignore', 'pipe', 'pipe'],
+		})
+		const stderr = captureStderr(child)
+		let stdout = ''
+		child.stdout?.on('data', (data: Buffer) => {
+			stdout += data.toString('utf8')
+		})
+
+		const [code] = (await Promise.race([
+			once(child, 'exit'),
+			new Promise((_, reject) => {
+				setTimeout(
+					() =>
+						reject(
+							new Error(
+								`Timed out waiting for deployed start to exit after child crash\nstdout:\n${stdout}\nstderr:\n${stderr()}`,
+							),
+						),
+					10000,
+				)
+			}),
+		])) as [number | null]
+
+		expect(code, `stdout:\n${stdout}\nstderr:\n${stderr()}`).toBe(42)
+	},
+	15000,
+)
+
+testIf(
 	'start releases the child server port on shutdown',
 	async () => {
 		await using fixture = await createRunnerFixture()
@@ -115,6 +159,87 @@ test('formatWorkshopAppResolutionErrorMessage lists attempted directories', () =
 		].join('\n'),
 	)
 })
+
+async function createDeployedCrashFixture() {
+	const rootDir = await createTempDir('epicshop-deployed-crash-')
+	const appDir = path.join(rootDir.path, 'fake-workshop-app')
+	await mkdir(appDir, { recursive: true })
+
+	// No local `app/` directory => treated as a published install, so start.js is used.
+	await writeFile(
+		path.join(appDir, 'package.json'),
+		JSON.stringify(
+			{
+				name: '@epic-web/workshop-app',
+				version: '6.90.17',
+				type: 'module',
+			},
+			null,
+			2,
+		),
+	)
+	await writeFile(
+		path.join(appDir, 'start.js'),
+		[
+			"console.error('simulated deployed child crash')",
+			'process.exit(42)',
+			'',
+		].join('\n'),
+	)
+
+	const workshopDir = path.join(rootDir.path, 'workshop')
+	await mkdir(workshopDir, { recursive: true })
+	await writeFile(
+		path.join(workshopDir, 'package.json'),
+		JSON.stringify(
+			{
+				name: 'fake-workshop',
+				version: '0.0.0',
+				type: 'module',
+				epicshop: {
+					githubRepo: 'https://github.com/example/fake-workshop',
+				},
+			},
+			null,
+			2,
+		),
+	)
+
+	const runnerPath = path.join(rootDir.path, 'start-runner.ts')
+	const startModuleUrl = pathToFileURL(
+		path.join(
+			repoRoot,
+			'packages',
+			'workshop-cli',
+			'src',
+			'commands',
+			'start.ts',
+		),
+	).href
+
+	await writeFile(
+		runnerPath,
+		[
+			`import { start } from ${JSON.stringify(startModuleUrl)}`,
+			'',
+			'start({ appLocation: process.env.EPICSHOP_APP_LOCATION })',
+			'  .catch((error) => {',
+			'    console.error(error)',
+			'    process.exit(1)',
+			'  })',
+			'',
+		].join('\n'),
+	)
+
+	return {
+		appDir,
+		workshopDir,
+		runnerPath,
+		async [Symbol.asyncDispose]() {
+			await rm(rootDir.path, { recursive: true, force: true })
+		},
+	}
+}
 
 async function createRunnerFixture() {
 	const rootDir = await createTempDir('epicshop-start-')

--- a/packages/workshop-cli/src/commands/start.ts
+++ b/packages/workshop-cli/src/commands/start.ts
@@ -464,7 +464,15 @@ export async function start(options: StartOptions = {}): Promise<StartResult> {
 				if (restarting) {
 					restarting = false
 				} else {
-					await new Promise((resolve) => server?.close(resolve))
+					// In deployed mode there is no parent HTTP server. Optional chaining
+					// would leave this promise pending forever, the event loop would
+					// drain, and Node would exit 0 — so Fly's on-failure restart policy
+					// would never bring the app back after a child crash.
+					if (server) {
+						await new Promise<void>((resolve) => {
+							server!.close(() => resolve())
+						})
+					}
 					process.exit(code ?? 0)
 				}
 			})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Epicshop `6.90.17` caused a mass Fly deploy outage across workshop apps. Three failures stacked:

1. **Boot regression in 6.90.17**: `instrument.js` imports `./sentry-server-filters.js`, but that file was omitted from the npm `files` list. On Sentry-enabled Fly apps (`SENTRY_DSN` set), `epicshop start` preloads `instrument.js` and the child crashes with `ERR_MODULE_NOT_FOUND`.
2. **Deployed exit-code bug**: in `EPICSHOP_DEPLOYED` mode the parent has no HTTP server, but the child `exit` handler still did `await new Promise(resolve => server?.close(resolve))`. Optional chaining left that promise pending forever, the event loop drained, and Node exited **0**. Fly's `on-failure` restart policy therefore never restarted the crashed guest.
3. **Mass-update stampede**: Update Workshops pushed ~34 repos nearly at once. Deploy workflows then raced Fly leases / machines API health waits, so failed rolling updates left many apps on the broken release image with only stopped machines.

**Note:** `*.epicweb.dev` currently resolves to Vercel (`DEPLOYMENT_NOT_FOUND`). Fly health is verified on `https://epicweb-dev-<app>.fly.dev/resources/healthcheck`. Some Fly app names differ from the repo name (e.g. `react-e2e-testing-with-playwright` → `epicweb-dev-e2e-react-application-testing-with-playwright`).

**Do not recover by `workflow_dispatch` on current workshop workflows** — deploy jobs are gated to `push` events, so dispatch can report workflow success without deploying. Recovery used re-runs of pre-outage **push** deploy runs (July 20).

## Fixes in this PR

### Boot / process lifecycle
- Publish `sentry-server-filters.js` (+ `.d.ts`) in `@epic-web/workshop-app` `files`
- Propagate child exit codes correctly in deployed start
- Tests for both

### Mass-update / deploy hardening
- Stagger Update Workshops pushes (default 90s) and raise workflow timeout to 120m
- Canonical workshop deploy workflow: `flyctl deploy` retries, post-deploy HTTP health probe on `*.fly.dev`, robust `fly.yaml` app-name parsing (quoted or unquoted), and `workflow_dispatch` deploys on main for sequenced recovery
- Patch workshop `fly.yaml` HTTP/TCP health-check grace periods (60s / 30s)
- Document the failure mode in `docs/deployment.md`

## Recovery status — complete

All 18 targeted apps return HTTP 200 on Fly healthcheck after sequenced July 20 push-deploy re-runs:

- workshop-template
- advanced-vitest-patterns
- testing-fundamentals
- programming-foundations
- type-safety
- structured-data
- object-oriented-typescript
- advanced-typescript
- tailwindcss-color-tokens
- mocking-techniques
- pixel-perfect-tailwind
- react-component-testing-with-vitest
- react-e2e-testing-with-playwright (`epicweb-dev-e2e-react-application-testing-with-playwright`)
- get-started-with-react
- mcp-auth
- advanced-react-apis
- react-and-the-vanishing-network
- mcp-ui

## After merge

- Cut patch release (`6.90.18`) with published `sentry-server-filters` + start exit fix
- Re-run Update Workshops (now staggered) so workshops pick up the fixed package + hardened deploy workflow

## Test plan

- [x] `published-files.test.ts` fails if `instrument.js` imports an unpublished relative file
- [x] Deployed start exit-code aha test
- [x] Local repro of 6.90.17 missing `sentry-server-filters.js`
- [x] CI green
- [x] App-name parser handles quoted and unquoted `fly.yaml` values
- [x] Live Fly healthchecks green for the failed set after sequenced recovery

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f52f561-c4d5-4238-916c-f553cd678aa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f52f561-c4d5-4238-916c-f553cd678aa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

