### PR TITLE
fix: stop exercise 404 boundary crash on scanner paths (EPICSHOP-H8)

### DIFF
--- a/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
@@ -9,7 +9,6 @@ import {
 	isExerciseStepApp,
 	isPlaygroundApp,
 	requireExercise,
-	requireExerciseApp,
 	type App,
 	type ExerciseStepApp,
 } from '@epic-web/workshop-utils/apps.server'
@@ -114,17 +113,18 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 		throw redirect(reqUrl.toString())
 	}
 
-	if (
-		(type === 'problem' && !problemApp) ||
-		(type === 'solution' && !solutionApp)
-	) {
+	// Invalid types (scanner paths like /exercise/wp-includes/l10n/min.php) and
+	// missing problem/solution apps all get a structured 404. Falling through used
+	// to throw a plain "Not found" string body via requireExerciseApp, which
+	// Exercise404ErrorBoundary cannot parse (EPICSHOP-H8).
+	const exerciseStepApp =
+		type === 'problem' ? problemApp : type === 'solution' ? solutionApp : null
+	if (!exerciseStepApp) {
 		const errorData = await getStep404Data({
 			exerciseNumber: params.exerciseNumber,
 		})
 		throw Response.json(errorData, { status: 404 })
 	}
-
-	const exerciseStepApp = await requireExerciseApp(params, cacheOptions)
 
 	const playgroundApp = allAppsFull.find(isPlaygroundApp)
 
@@ -326,7 +326,7 @@ export default function ExercisePartRoute({
 					style={{ ['--split-pct' as any]: `${splitPercent}%` }}
 					ref={leftPaneRef}
 				>
-					<h1 className="scrollbar-thumb-scrollbar @container h-14 max-w-full scrollbar-thin overflow-x-auto overflow-y-hidden border-b pr-5 pl-10 text-sm leading-tight font-medium">
+					<h1 className="scrollbar-thumb-scrollbar scrollbar-thin @container h-14 max-w-full overflow-x-auto overflow-y-hidden border-b pr-5 pl-10 text-sm leading-tight font-medium">
 						<div className="flex h-14 items-center justify-between gap-x-2 py-2 whitespace-nowrap">
 							<div className="flex items-center justify-start gap-x-2 uppercase">
 								<Link
@@ -370,7 +370,7 @@ export default function ExercisePartRoute({
 					<article
 						id={data.articleId}
 						key={data.articleId}
-						className="shadow-on-scrollbox scrollbar-thumb-scrollbar flex w-full max-w-none scroll-pt-6 scrollbar-thin flex-col justify-between space-y-6 p-2 sm:p-10 sm:pt-8 lg:h-full lg:flex-1 lg:overflow-y-auto"
+						className="shadow-on-scrollbox scrollbar-thumb-scrollbar scrollbar-thin flex w-full max-w-none scroll-pt-6 flex-col justify-between space-y-6 p-2 sm:p-10 sm:pt-8 lg:h-full lg:flex-1 lg:overflow-y-auto"
 					>
 						{data.exerciseStepApp.instructionsCode ? (
 							<StepMdx inBrowserBrowserRef={inBrowserBrowserRef} />

--- a/packages/workshop-app/app/routes/_app+/exercise+/__shared/error-boundary.tsx
+++ b/packages/workshop-app/app/routes/_app+/exercise+/__shared/error-boundary.tsx
@@ -33,18 +33,24 @@ export function Exercise404ErrorBoundary({
 	error: ErrorResponse
 	params: Record<string, string | undefined>
 }) {
-	console.log(error)
 	const validationResult = error404Schema.safeParse(error.data)
 	const label = [params.exerciseNumber, params.stepNumber, params.type]
 		.filter(Boolean)
 		.join('.')
 
 	if (!validationResult.success) {
-		console.error(
-			'Invalid 404 error response data',
-			validationResult.error,
-			error,
-		)
+		// Plain string 404 bodies (e.g. requireExerciseApp, scanners hitting
+		// /exercise/wp-includes/...) are expected. Only warn when an object
+		// payload fails our schema — that means our own 404 shape drifted.
+		// Log primitives only: console.error(ZodError | ErrorResponse) has
+		// thrown inside Node util.inspect under Sentry's console wrapper
+		// (EPICSHOP-H8: Cannot read properties of undefined (reading 'value')).
+		if (error.data !== null && typeof error.data === 'object') {
+			console.error(
+				'Invalid 404 error response data',
+				validationResult.error.message,
+			)
+		}
 		return <p className="text-2xl font-bold">"{label}" not found</p>
 	}
 	const { data } = validationResult

--- a/packages/workshop-app/tests/exercise-404-error-boundary.test.tsx
+++ b/packages/workshop-app/tests/exercise-404-error-boundary.test.tsx
@@ -1,0 +1,88 @@
+import { renderToString } from 'react-dom/server'
+import {
+	MemoryRouter,
+	UNSAFE_ErrorResponseImpl as ErrorResponseImpl,
+} from 'react-router'
+import { expect, test, vi } from 'vitest'
+import { Exercise404ErrorBoundary } from '../app/routes/_app+/exercise+/__shared/error-boundary.tsx'
+
+function renderBoundary(
+	error: ErrorResponseImpl,
+	params: Record<string, string | undefined>,
+) {
+	return renderToString(
+		<MemoryRouter>
+			<Exercise404ErrorBoundary error={error} params={params} />
+		</MemoryRouter>,
+	)
+}
+
+test('renders a plain not-found for string 404 bodies without console.error (aha: EPICSHOP-H8)', () => {
+	const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+	const error = new ErrorResponseImpl(404, '', 'Not found', false)
+	const params = {
+		exerciseNumber: 'wp-includes',
+		stepNumber: 'l10n',
+		type: 'min.php',
+	}
+
+	expect(() => renderBoundary(error, params)).not.toThrow()
+
+	const html = renderBoundary(error, params)
+	expect(html).toContain('wp-includes.l10n.min.php')
+	expect(html).toContain('not found')
+	expect(errorSpy).not.toHaveBeenCalled()
+	errorSpy.mockRestore()
+})
+
+test('renders step-not-found guidance when the 404 payload matches the schema', () => {
+	const error = new ErrorResponseImpl(
+		404,
+		'',
+		{
+			type: 'step-not-found',
+			steps: [
+				{
+					stepNumber: 1,
+					title: 'Hello',
+					hasProblem: true,
+					hasSolution: false,
+				},
+			],
+			exerciseNumber: 1,
+			exerciseTitle: 'Intro',
+		},
+		false,
+	)
+
+	const html = renderBoundary(error, {
+		exerciseNumber: '01',
+		stepNumber: '99',
+		type: 'problem',
+	})
+	expect(html).toContain('Step not found')
+	expect(html).toContain('Hello')
+	expect(html).toContain('Available Steps')
+})
+
+test('logs only a string message when an object 404 payload fails the schema', () => {
+	const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+	const error = new ErrorResponseImpl(
+		404,
+		'',
+		{ type: 'unexpected', oops: true },
+		false,
+	)
+
+	renderBoundary(error, {
+		exerciseNumber: '01',
+		stepNumber: '01',
+		type: 'problem',
+	})
+
+	expect(errorSpy).toHaveBeenCalledOnce()
+	const [message, details] = errorSpy.mock.calls[0] ?? []
+	expect(message).toBe('Invalid 404 error response data')
+	expect(typeof details).toBe('string')
+	errorSpy.mockRestore()
+})

--- a/packages/workshop-app/vitest.sentry-noise.config.ts
+++ b/packages/workshop-app/vitest.sentry-noise.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
 	test: {
 		name: 'app-sentry-noise',
 		include: ['tests/*.{test,spec}.{ts,tsx}'],
+		exclude: ['tests/*.browser.{test,spec}.{ts,tsx}'],
 		setupFiles: ['../../tests/vitest-setup.ts'],
 		mockReset: true,
 	},

--- a/packages/workshop-app/vitest.sentry-noise.config.ts
+++ b/packages/workshop-app/vitest.sentry-noise.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
 	test: {
 		name: 'app-sentry-noise',
-		include: ['tests/*.test.ts'],
+		include: ['tests/*.{test,spec}.{ts,tsx}'],
 		setupFiles: ['../../tests/vitest-setup.ts'],
 		mockReset: true,
 	},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [EPICSHOP-H8](https://kent-c-dodds-tech-llc.sentry.io/issues/7632078724/): `TypeError: Cannot read properties of undefined (reading 'value')` on `GET *splat`.

WordPress-style scanner hits like `/exercise/wp-includes/l10n/min.php` matched the exercise step route with an invalid `type`. The layout fell through to `requireExerciseApp`, which threw a plain `"Not found"` string 404. `Exercise404ErrorBoundary` then `console.error`'d a ZodError + ErrorResponse, and Node's `util.inspect` threw under Sentry's console wrapper during SSR — turning expected 404 noise into a Sentry error.

## Changes

- Exercise step layout now returns a structured JSON 404 for invalid types and missing apps (same shape as real step/exercise-not-found payloads).
- `Exercise404ErrorBoundary` treats non-object 404 bodies as a normal not-found UI without logging; when an object payload fails the schema, it logs only a string message (no ZodError/ErrorResponse objects).
- Adds regression tests for the string-body / logging behavior.

## Status

- Squash-merged as `b527686982822bd2055f10579b3d7904f408df2e`
- Sentry issue resolved in that commit
- CI: https://github.com/epicweb-dev/epicshop/actions/runs/30326747963

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed14d902-8d49-4412-beaf-9d53b686415f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed14d902-8d49-4412-beaf-9d53b686415f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

