### PR TITLE
fix: filter MCP stdio deserialize ZodError Sentry noise (EPICSHOP-89)

### DIFF
--- a/packages/workshop-mcp/src/sentry-filters.test.ts
+++ b/packages/workshop-mcp/src/sentry-filters.test.ts
@@ -138,7 +138,8 @@ test('keeps unrelated JsonRpcError events', () => {
 test('drops MCP stdio deserialize ZodError transport noise (aha)', () => {
 	expect(
 		isExpectedMcpSentryNoise({
-			culprit: 'deserializeMessage(@modelcontextprotocol.sdk.dist.esm.shared:stdio)',
+			culprit:
+				'deserializeMessage(@modelcontextprotocol.sdk.dist.esm.shared:stdio)',
 			exception: {
 				values: [
 					{
@@ -188,7 +189,8 @@ test('keeps unrelated ZodErrors outside MCP transport deserialize', () => {
 				values: [
 					{
 						type: 'ZodError',
-						value: '[\n  {\n    "code": "invalid_type",\n    "path": ["name"]\n  }\n]',
+						value:
+							'[\n  {\n    "code": "invalid_type",\n    "path": ["name"]\n  }\n]',
 						mechanism: {
 							type: 'generic',
 							data: { error_type: 'tool' },

--- a/packages/workshop-mcp/src/sentry-filters.test.ts
+++ b/packages/workshop-mcp/src/sentry-filters.test.ts
@@ -134,3 +134,77 @@ test('keeps unrelated JsonRpcError events', () => {
 		}),
 	).toBe(false)
 })
+
+test('drops MCP stdio deserialize ZodError transport noise (aha)', () => {
+	expect(
+		isExpectedMcpSentryNoise({
+			culprit: 'deserializeMessage(@modelcontextprotocol.sdk.dist.esm.shared:stdio)',
+			exception: {
+				values: [
+					{
+						type: 'ZodError',
+						value:
+							'[\n  {\n    "code": "invalid_union",\n    "path": ["id"],\n    "message": "Invalid input"\n  }\n]',
+						mechanism: {
+							type: 'auto.ai.mcp_server',
+							data: { error_type: 'transport' },
+						},
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('drops ZodError when stack is deserializeMessage from MCP SDK stdio', () => {
+	expect(
+		isExpectedMcpSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'ZodError',
+						value: '[\n  {\n    "code": "invalid_type"\n  }\n]',
+						stacktrace: {
+							frames: [
+								{
+									function: 'deserializeMessage',
+									module: '@modelcontextprotocol.sdk.dist.esm.shared:stdio',
+									filename:
+										'/Users/example/.npm/_npx/x/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('keeps unrelated ZodErrors outside MCP transport deserialize', () => {
+	expect(
+		isExpectedMcpSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'ZodError',
+						value: '[\n  {\n    "code": "invalid_type",\n    "path": ["name"]\n  }\n]',
+						mechanism: {
+							type: 'generic',
+							data: { error_type: 'tool' },
+						},
+						stacktrace: {
+							frames: [
+								{
+									function: 'parseToolArgs',
+									module: 'workshop-mcp/tools',
+									filename: '/tmp/workshop-mcp/src/tools.ts',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+})

--- a/packages/workshop-mcp/src/sentry-filters.ts
+++ b/packages/workshop-mcp/src/sentry-filters.ts
@@ -21,9 +21,23 @@ const expectedMcpErrorMessagePatterns = [
 type SentryExceptionValue = {
 	type?: string
 	value?: string
+	mechanism?: {
+		type?: string
+		data?: {
+			error_type?: string
+		}
+	}
+	stacktrace?: {
+		frames?: Array<{
+			function?: string
+			module?: string
+			filename?: string
+		}>
+	}
 }
 
 type SentryEventWithException = {
+	culprit?: string
 	exception?: {
 		values?: Array<SentryExceptionValue>
 	}
@@ -33,6 +47,35 @@ export function isExpectedMcpErrorMessage(message: string) {
 	return expectedMcpErrorMessagePatterns.some((pattern) =>
 		pattern.test(message),
 	)
+}
+
+/**
+ * MCP hosts sometimes send malformed JSON-RPC frames on stdio. The SDK's
+ * deserializeMessage validates with Zod and throws ZodError (transport noise),
+ * which Sentry's MCP integration captures as mechanism auto.ai.mcp_server.
+ */
+function isMcpTransportDeserializeZodError(
+	event: SentryEventWithException,
+	value: SentryExceptionValue,
+) {
+	if (value.type !== 'ZodError') return false
+
+	if (
+		value.mechanism?.type === 'auto.ai.mcp_server' &&
+		value.mechanism.data?.error_type === 'transport'
+	) {
+		return true
+	}
+
+	if (event.culprit?.includes('deserializeMessage')) return true
+
+	return (value.stacktrace?.frames ?? []).some((frame) => {
+		if (frame.function !== 'deserializeMessage') return false
+		const location = `${frame.module ?? ''} ${frame.filename ?? ''}`
+		return (
+			location.includes('@modelcontextprotocol') || location.includes('stdio')
+		)
+	})
 }
 
 export function isExpectedMcpSentryNoise(
@@ -54,6 +97,7 @@ export function isExpectedMcpSentryNoise(
 	return (
 		event.exception?.values?.some((value) => {
 			if (value.type === 'ExpectedMcpError') return true
+			if (isMcpTransportDeserializeZodError(event, value)) return true
 			if (
 				typeof value.value === 'string' &&
 				isExpectedMcpErrorMessage(value.value)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- MCP hosts sometimes send malformed JSON-RPC frames over stdio. The MCP SDK validates them in `deserializeMessage` and throws `ZodError` (missing `id`, null `params`, etc.).
- Sentry's MCP integration captures these as `auto.ai.mcp_server` transport errors. That is client/host protocol noise, not an epicshop bug.
- Narrow `beforeSend` filter in `@epic-web/workshop-mcp` drops only ZodErrors tied to MCP transport deserialize (`error_type: transport`, `deserializeMessage` culprit/stack). Unrelated ZodErrors still report.

## Sentry

- [EPICSHOP-89](https://kent-c-dodds-tech-llc.sentry.io/issues/7076234911/) (156 events) — ignored after filter
- Sibling same root cause: [EPICSHOP-AN](https://kent-c-dodds-tech-llc.sentry.io/issues/7201435270/) (242 events) — ignored

## Status

Squash-merged as `79058956`. CI validate green.

## Test plan

- [x] `nx run @epic-web/workshop-mcp:test -- sentry-filters`
- [x] CI validate / AI review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c643dd0-1298-443f-b011-80edf4e414b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c643dd0-1298-443f-b011-80edf4e414b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

