### PR TITLE
fix: return 405 for GET /set-playground (EPICSHOP-AJ)

### DIFF
--- a/packages/workshop-app/app/routes/set-playground.tsx
+++ b/packages/workshop-app/app/routes/set-playground.tsx
@@ -47,6 +47,16 @@ const SetPlaygroundSchema = z.object({
 		.transform((v) => v === 'true'),
 })
 
+// This route only accepts POST (fetcher/form actions). Without a loader,
+// React Router turns a GET into a reported internal "did not provide a
+// loader" error instead of a 405 — bots crawl /set-playground often.
+export function loader() {
+	return new Response('Method Not Allowed', {
+		status: 405,
+		headers: { Allow: 'POST' },
+	})
+}
+
 export async function action({ request }: Route.ActionArgs) {
 	ensureUndeployed()
 	const formData = await request.formData()

--- a/packages/workshop-app/app/routes/set-playground.tsx
+++ b/packages/workshop-app/app/routes/set-playground.tsx
@@ -578,7 +578,7 @@ export function PlaygroundChooser({
 						fetcher.data?.status === 'error' ? 'cursor-not-allowed' : null,
 					)}
 				>
-					<span className="scrollbar-thumb-scrollbar w-80 flex-1 scrollbar-thin truncate">
+					<span className="scrollbar-thumb-scrollbar scrollbar-thin w-80 flex-1 truncate">
 						<Select.Value
 							placeholder="Select current app"
 							className="inline-block w-40 truncate"

--- a/packages/workshop-app/tests/set-playground-route.test.ts
+++ b/packages/workshop-app/tests/set-playground-route.test.ts
@@ -1,0 +1,28 @@
+import { expect, test, vi } from 'vitest'
+
+vi.mock('@epic-web/workshop-utils/apps.server', () => ({
+	getAppByName: vi.fn(),
+	getApps: vi.fn(),
+	isPlaygroundApp: vi.fn(),
+	isProblemApp: vi.fn(),
+	isSolutionApp: vi.fn(),
+	setPlayground: vi.fn(),
+}))
+vi.mock('@epic-web/workshop-utils/db.server', () => ({
+	markOnboardingComplete: vi.fn(),
+}))
+vi.mock('@epic-web/workshop-utils/diff.server', () => ({
+	getDiffPatch: vi.fn(),
+}))
+vi.mock('@epic-web/workshop-utils/process-manager.server', () => ({
+	clearTestProcessEntry: vi.fn(),
+}))
+
+const { loader } = await import('../app/routes/set-playground.tsx')
+
+test('returns 405 for GET because a resource route with no loader makes React Router report an internal server error (aha)', () => {
+	const response = loader()
+
+	expect(response.status).toBe(405)
+	expect(response.headers.get('Allow')).toBe('POST')
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [EPICSHOP-AJ](https://kent-c-dodds-tech-llc.sentry.io/issues/7199638778/) (`getInternalRouterError` on `GET *splat`).

PR #630 already:

1. Stopped reporting React Router client 4xx `ErrorResponse`s from `handleError` (`isClientErrorResponse`)
2. Added a 405 `loader` on `/resources/lookout` (the previous dominant path in this issue)

After that shipped as v6.90.17, the issue re-alerted because crawlers still `GET /set-playground`. That route only exported an `action`, so React Router answered with `getInternalRouterError` ("did not provide a `loader`"). Latest production events are bot/crawler GETs to deployed workshops (often still on pre-6.90.17 pins such as 6.90.13).

## Changes

- `set-playground` now exports a `loader` that returns **405** with `Allow: POST` (same pattern as `resources+/lookout`)
- Adds a regression test in the `app-sentry-noise` vitest project

## Siblings (same backfill)

| Issue | Disposition |
| --- | --- |
| EPICSHOP-GD / FQ / GP (`getInternalRouterError` missing action/loader) | Covered by #630 `isClientErrorResponse`; ignore after this ships |
| EPICSHOP-G8 (`Error: Bad Request` / Codespaces Origin vs `X-Forwarded-Host`) | Sentry noise covered by #630 4xx filter; underlying CSRF/proxy mismatch deliberately deferred in #630 |
| EPICSHOP-EW (ByteString PE redirect) | Already fixed in #602 / #594; ignore/resolve as stale |

## Test plan

- [x] `npx vitest run --project app-sentry-noise packages/workshop-app/tests/set-playground-route.test.ts`
- [ ] CI validate (build/typecheck/lint/test)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7f369f8-3a53-4d3f-b90d-94af16ac82ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7f369f8-3a53-4d3f-b90d-94af16ac82ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

