### PR TITLE
fix: filter React render-loop fatals from extension addEL_hook (EPICSHOP-FW)

### DIFF
--- a/packages/workshop-app/app/utils/sentry-filters.ts
+++ b/packages/workshop-app/app/utils/sentry-filters.ts
@@ -5,7 +5,18 @@ type SentryExceptionValue = {
 		frames?: Array<{
 			filename?: string
 			function?: string
+			module?: string
+			inApp?: boolean
 		}>
+	}
+}
+
+type SentryBreadcrumb = {
+	category?: string
+	message?: string
+	level?: string
+	data?: {
+		arguments?: Array<unknown>
 	}
 }
 
@@ -16,6 +27,7 @@ type SentryEventWithException = {
 	request?: {
 		url?: string
 	}
+	breadcrumbs?: Array<SentryBreadcrumb> | { values?: Array<SentryBreadcrumb> }
 }
 
 export const processingPictureInPictureRequestMessage =
@@ -167,6 +179,63 @@ export function isPlaygroundClientNoise(event: SentryEventWithException) {
 	)
 }
 
+function getBreadcrumbs(event: SentryEventWithException) {
+	const crumbs = event.breadcrumbs
+	if (!crumbs) return []
+	return Array.isArray(crumbs) ? crumbs : (crumbs.values ?? [])
+}
+
+function breadcrumbTextBlob(event: SentryEventWithException) {
+	const parts: Array<string> = []
+	for (const crumb of getBreadcrumbs(event)) {
+		if (typeof crumb.message === 'string') parts.push(crumb.message)
+		for (const arg of crumb.data?.arguments ?? []) {
+			if (typeof arg === 'string') {
+				parts.push(arg)
+				continue
+			}
+			if (arg && typeof arg === 'object') {
+				const record = arg as { message?: unknown; stack?: unknown }
+				if (typeof record.message === 'string') parts.push(record.message)
+				if (typeof record.stack === 'string') parts.push(record.stack)
+			}
+		}
+	}
+	return parts.join('\n')
+}
+
+function isReactRenderLoopFatal(event: SentryEventWithException) {
+	return getExceptionValues(event).some((value) => {
+		const text = exceptionValueText(value)
+		return (
+			/Maximum update depth exceeded/i.test(text) ||
+			/^Should not already be working\.?$/i.test(text) ||
+			/Minified React error #185/i.test(text)
+		)
+	})
+}
+
+/**
+ * Browser extensions that wrap addEventListener (`addEL_hook`) throw
+ * `Cannot read properties of null (reading 'tagName')` while React mounts
+ * effects. React Router catches the throw during render/effect recovery, which
+ * then fatals as "Maximum update depth exceeded" / "Should not already be
+ * working" with only react-dom frames — so the underlying extension filter
+ * never matches. Drop these cascade fatals when breadcrumbs show the hook.
+ */
+export function isReactExtensionRenderLoopNoise(
+	event: SentryEventWithException,
+) {
+	if (!isReactRenderLoopFatal(event)) return false
+
+	const crumbText = breadcrumbTextBlob(event)
+	if (/addEL_hook/i.test(crumbText)) return true
+	return (
+		/reading ['"]tagName['"]/i.test(crumbText) &&
+		/React Router caught/i.test(crumbText)
+	)
+}
+
 export function isClientSentryNoise(event: SentryEventWithException) {
 	return (
 		isProcessingPictureInPictureRequest(event) ||
@@ -176,6 +245,7 @@ export function isClientSentryNoise(event: SentryEventWithException) {
 		isCrossOriginSecurityNoise(event) ||
 		isBrowserExtensionNoise(event) ||
 		isDomMutationNoise(event) ||
-		isPlaygroundClientNoise(event)
+		isPlaygroundClientNoise(event) ||
+		isReactExtensionRenderLoopNoise(event)
 	)
 }

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -267,7 +267,8 @@ test('drops React render-loop fatals cascaded from addEL_hook extensions (aha)',
 				{
 					category: 'console',
 					level: 'error',
-					message: "TypeError: Cannot read properties of null (reading 'tagName')",
+					message:
+						"TypeError: Cannot read properties of null (reading 'tagName')",
 					data: {
 						arguments: [
 							{

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -8,6 +8,7 @@ import {
 	isDomMutationNoise,
 	isPlaygroundClientNoise,
 	isProcessingPictureInPictureRequest,
+	isReactExtensionRenderLoopNoise,
 	isSessionStorageAccessDenied,
 	processingPictureInPictureRequestMessage,
 } from '../app/utils/sentry-filters.ts'
@@ -250,6 +251,67 @@ test('drops DOM mutation races and playground client frames', () => {
 	).toBe(true)
 })
 
+test('drops React render-loop fatals cascaded from addEL_hook extensions (aha)', () => {
+	expect(
+		isReactExtensionRenderLoopNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value:
+							'Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.',
+					},
+				],
+			},
+			breadcrumbs: [
+				{
+					category: 'console',
+					level: 'error',
+					message: "TypeError: Cannot read properties of null (reading 'tagName')",
+					data: {
+						arguments: [
+							{
+								message: "Cannot read properties of null (reading 'tagName')",
+								stack:
+									"TypeError: Cannot read properties of null (reading 'tagName')\n    at addEL_hook (<anonymous>:675:29)\n    at top.addEventListener (<anonymous>:695:9)",
+							},
+						],
+					},
+				},
+				{
+					category: 'console',
+					level: 'error',
+					message:
+						"React Router caught the following error during render TypeError: Cannot read properties of null (reading 'tagName')",
+				},
+			],
+		}),
+	).toBe(true)
+	expect(
+		isReactExtensionRenderLoopNoise({
+			exception: {
+				values: [{ type: 'Error', value: 'Should not already be working.' }],
+			},
+			breadcrumbs: {
+				values: [
+					{
+						message:
+							"React Router caught the following error during render TypeError: Cannot read properties of null (reading 'tagName')",
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	// Real product render loops without extension breadcrumbs must still alert.
+	expect(
+		isReactExtensionRenderLoopNoise({
+			exception: {
+				values: [{ type: 'Error', value: 'Maximum update depth exceeded' }],
+			},
+		}),
+	).toBe(false)
+})
+
 test('isClientSentryNoise aggregates the client predicates', () => {
 	expect(
 		isClientSentryNoise({
@@ -265,6 +327,18 @@ test('isClientSentryNoise aggregates the client predicates', () => {
 			},
 		}),
 	).toBe(false)
+	expect(
+		isClientSentryNoise({
+			exception: {
+				values: [{ type: 'Error', value: 'Should not already be working.' }],
+			},
+			breadcrumbs: [
+				{
+					message: 'at addEL_hook (<anonymous>:675:29)',
+				},
+			],
+		}),
+	).toBe(true)
 })
 
 test('drops learner-machine server environment noise (aha)', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry **EPICSHOP-FW** (`Maximum update depth exceeded`) and sibling **EPICSHOP-FS** (`Should not already be working`) are the same crash cascade (identical users/timestamps/replays).

Root cause is **not** workshop/exercise code: every event’s breadcrumbs show a browser extension hook:

```
TypeError: Cannot read properties of null (reading 'tagName')
    at addEL_hook (<anonymous>)
    at top.addEventListener (<anonymous>)
```

That throw happens while React mounts effects; React Router catches it during render/effect recovery, then fatals with only `react-dom` / `scheduler` frames. The underlying `tagName` + `addEL_hook` exception is already filtered by `isBrowserExtensionNoise`; these cascade fatals were slipping through.

## Change

- Add `isReactExtensionRenderLoopNoise` in client `sentry-filters.ts`
- Drop max-update-depth / “Should not already be working” / React `#185` **only when** breadcrumbs evidence the extension (`addEL_hook` or tagName + “React Router caught”)
- Leave bare max-update-depth events unfiltered so real product loops still alert
- Unit tests cover the aha case

## Risk

**Low** — drop-only client filter with tests; no auth/data surface.

## Test plan

- [x] `npx vitest run --config vitest.sentry-noise.config.ts tests/sentry-filters.test.ts`
- [x] `npm run validate`
- [x] CI green (`validate` workflow)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7464-640f-4702-8dba-0b10e3567b72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7464-640f-4702-8dba-0b10e3567b72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

