### PR TITLE
fix: stop Codespaces CSRF 400s from surfacing as Unexpected Server Error (EPICSHOP-6)

### DIFF
--- a/packages/workshop-app/app/utils/route-errors.ts
+++ b/packages/workshop-app/app/utils/route-errors.ts
@@ -4,8 +4,18 @@ import { isRouteErrorResponse } from 'react-router'
 // missing loader/action for the method) through the server handleError hook
 // even though it has already answered the request with that 4xx status, so
 // they are client mistakes, not server faults.
+//
+// The single-fetch CSRF guard is the other case: it catches a descriptive
+// origin-mismatch Error and re-reports a bare Error("Bad Request") through
+// handleError while already answering with HTTP 400. That is not a server
+// fault (Codespaces proxy mismatch or a cross-site probe).
 export function isClientErrorResponse(error: unknown) {
-	return (
-		isRouteErrorResponse(error) && error.status >= 400 && error.status < 500
-	)
+	if (
+		isRouteErrorResponse(error) &&
+		error.status >= 400 &&
+		error.status < 500
+	) {
+		return true
+	}
+	return error instanceof Error && error.message === 'Bad Request'
 }

--- a/packages/workshop-app/app/utils/sentry-filters.ts
+++ b/packages/workshop-app/app/utils/sentry-filters.ts
@@ -236,6 +236,19 @@ export function isReactExtensionRenderLoopNoise(
 	)
 }
 
+/**
+ * React Router sanitizes production single-fetch errors to this opaque message
+ * with no stack. The actionable server exception (when any) is reported via
+ * handleError; the client mirror is never actionable on its own.
+ */
+export function isUnexpectedServerErrorNoise(event: SentryEventWithException) {
+	return getExceptionValues(event).some(
+		(value) =>
+			value.type === 'Error' &&
+			exceptionValueText(value) === 'Unexpected Server Error',
+	)
+}
+
 export function isClientSentryNoise(event: SentryEventWithException) {
 	return (
 		isProcessingPictureInPictureRequest(event) ||
@@ -246,6 +259,7 @@ export function isClientSentryNoise(event: SentryEventWithException) {
 		isBrowserExtensionNoise(event) ||
 		isDomMutationNoise(event) ||
 		isPlaygroundClientNoise(event) ||
-		isReactExtensionRenderLoopNoise(event)
+		isReactExtensionRenderLoopNoise(event) ||
+		isUnexpectedServerErrorNoise(event)
 	)
 }

--- a/packages/workshop-app/server/align-loopback-origin.ts
+++ b/packages/workshop-app/server/align-loopback-origin.ts
@@ -8,12 +8,12 @@ import { type NextFunction, type Request, type Response } from 'express'
  * the client surfaces React Router's opaque "Unexpected Server Error".
  *
  * The same mismatch happens when a learner opens the app as `127.0.0.1` while
- * `Host` is `localhost` (or the reverse).
+ * `Host` is `localhost` (or the reverse) on the *same* port.
  *
- * For undeployed local workshops only, when `Origin` is a loopback host, align
- * `Host` / `X-Forwarded-Host` to that Origin so CSRF compares equal hosts.
- * Deployed workshops keep strict proxy header behavior. Cross-site scanner
- * Origins (not loopback) are unchanged and still rejected.
+ * For undeployed local workshops only, align headers in those two cases.
+ * Different loopback ports are left alone so a page on another local port
+ * cannot satisfy CSRF by getting `Host` rewritten. Deployed workshops keep
+ * strict proxy header behavior. Cross-site scanner Origins are unchanged.
  */
 export function isLoopbackHost(host: string) {
 	try {
@@ -41,6 +41,14 @@ export function getOriginHost(originHeader: string | undefined) {
 	}
 }
 
+export function getHostPort(host: string) {
+	try {
+		return new URL(`http://${host}`).port
+	} catch {
+		return null
+	}
+}
+
 export function shouldAlignLoopbackOriginHeaders({
 	deployed,
 	originHost,
@@ -53,11 +61,31 @@ export function shouldAlignLoopbackOriginHeaders({
 	forwardedHostHeader: string | undefined
 }) {
 	if (deployed || !originHost || !isLoopbackHost(originHost)) return false
-	const forwardedHost = forwardedHostHeader?.split(',')[0]?.trim()
-	return (
-		(Boolean(forwardedHost) && forwardedHost !== originHost) ||
-		(Boolean(hostHeader) && hostHeader !== originHost)
-	)
+
+	const forwardedHost = forwardedHostHeader?.split(',')[0]?.trim() || undefined
+
+	// Classic Codespaces: Host already matches the loopback Origin; only
+	// X-Forwarded-Host is the disagreeing public hostname.
+	if (
+		forwardedHost &&
+		forwardedHost !== originHost &&
+		hostHeader === originHost
+	) {
+		return true
+	}
+
+	// localhost vs 127.0.0.1 (same port only — different ports stay rejected)
+	if (
+		hostHeader &&
+		hostHeader !== originHost &&
+		isLoopbackHost(hostHeader) &&
+		getHostPort(originHost) !== null &&
+		getHostPort(originHost) === getHostPort(hostHeader)
+	) {
+		return true
+	}
+
+	return false
 }
 
 export function alignLoopbackOriginHeaders(

--- a/packages/workshop-app/server/align-loopback-origin.ts
+++ b/packages/workshop-app/server/align-loopback-origin.ts
@@ -1,0 +1,94 @@
+import { type NextFunction, type Request, type Response } from 'express'
+
+/**
+ * GitHub Codespaces (and similar port-forward proxies) often rewrite the
+ * browser `Origin` to `localhost:<port>` while setting `X-Forwarded-Host` to
+ * the public `*.app.github.dev` host. React Router's single-fetch CSRF check
+ * prefers `X-Forwarded-Host`, so legitimate same-tab POSTs fail with 400 and
+ * the client surfaces React Router's opaque "Unexpected Server Error".
+ *
+ * The same mismatch happens when a learner opens the app as `127.0.0.1` while
+ * `Host` is `localhost` (or the reverse).
+ *
+ * For undeployed local workshops only, when `Origin` is a loopback host, align
+ * `Host` / `X-Forwarded-Host` to that Origin so CSRF compares equal hosts.
+ * Deployed workshops keep strict proxy header behavior. Cross-site scanner
+ * Origins (not loopback) are unchanged and still rejected.
+ */
+export function isLoopbackHost(host: string) {
+	try {
+		// Host may include a port; URL parsing splits hostname safely for
+		// localhost, IPv4, and bracketed IPv6 (e.g. [::1]:5639). Node may keep
+		// the brackets on IPv6 hostnames, so accept both forms.
+		const hostname = new URL(`http://${host}`).hostname.toLowerCase()
+		return (
+			hostname === 'localhost' ||
+			hostname === '127.0.0.1' ||
+			hostname === '::1' ||
+			hostname === '[::1]'
+		)
+	} catch {
+		return false
+	}
+}
+
+export function getOriginHost(originHeader: string | undefined) {
+	if (!originHeader || originHeader === 'null') return null
+	try {
+		return new URL(originHeader).host
+	} catch {
+		return null
+	}
+}
+
+export function shouldAlignLoopbackOriginHeaders({
+	deployed,
+	originHost,
+	hostHeader,
+	forwardedHostHeader,
+}: {
+	deployed: boolean
+	originHost: string | null
+	hostHeader: string | undefined
+	forwardedHostHeader: string | undefined
+}) {
+	if (deployed || !originHost || !isLoopbackHost(originHost)) return false
+	const forwardedHost = forwardedHostHeader?.split(',')[0]?.trim()
+	return (
+		(Boolean(forwardedHost) && forwardedHost !== originHost) ||
+		(Boolean(hostHeader) && hostHeader !== originHost)
+	)
+}
+
+export function alignLoopbackOriginHeaders(
+	req: Request,
+	_res: Response,
+	next: NextFunction,
+) {
+	const originHost = getOriginHost(
+		typeof req.headers.origin === 'string' ? req.headers.origin : undefined,
+	)
+	const forwarded = req.headers['x-forwarded-host']
+	const forwardedHostHeader = Array.isArray(forwarded)
+		? forwarded[0]
+		: forwarded
+	const hostHeader = Array.isArray(req.headers.host)
+		? req.headers.host[0]
+		: req.headers.host
+
+	if (
+		!shouldAlignLoopbackOriginHeaders({
+			deployed: Boolean(ENV.EPICSHOP_DEPLOYED),
+			originHost,
+			hostHeader,
+			forwardedHostHeader,
+		})
+	) {
+		return next()
+	}
+
+	// originHost is non-null when shouldAlign... is true
+	req.headers.host = originHost!
+	delete req.headers['x-forwarded-host']
+	return next()
+}

--- a/packages/workshop-app/server/index.ts
+++ b/packages/workshop-app/server/index.ts
@@ -30,6 +30,7 @@ import morgan from 'morgan'
 import { type ServerBuild } from 'react-router'
 import sourceMapSupport from 'source-map-support'
 import { type WebSocket, WebSocketServer } from 'ws'
+import { alignLoopbackOriginHeaders } from './align-loopback-origin.ts'
 import {
 	decodeRequestTarget,
 	rejectMalformedRequests,
@@ -92,6 +93,7 @@ app.use(compression())
 app.disable('x-powered-by')
 
 app.use(rejectMalformedRequests)
+app.use(alignLoopbackOriginHeaders)
 
 // the workshop's public assets override the app's public assets
 app.use(

--- a/packages/workshop-app/tests/align-loopback-origin.test.ts
+++ b/packages/workshop-app/tests/align-loopback-origin.test.ts
@@ -1,0 +1,122 @@
+import { type Request, type Response } from 'express'
+import { expect, test, vi } from 'vitest'
+import {
+	alignLoopbackOriginHeaders,
+	getOriginHost,
+	isLoopbackHost,
+	shouldAlignLoopbackOriginHeaders,
+} from '../server/align-loopback-origin.ts'
+
+test('recognizes loopback hosts with and without ports (aha)', () => {
+	expect(isLoopbackHost('localhost')).toBe(true)
+	expect(isLoopbackHost('localhost:5639')).toBe(true)
+	expect(isLoopbackHost('127.0.0.1:5639')).toBe(true)
+	expect(isLoopbackHost('[::1]:5639')).toBe(true)
+	expect(isLoopbackHost('example.com')).toBe(false)
+	expect(
+		isLoopbackHost('literate-lamp-975vggxqvvhp4jx-5639.app.github.dev'),
+	).toBe(false)
+})
+
+test('parses Origin hosts and rejects invalid values', () => {
+	expect(getOriginHost('http://localhost:5639')).toBe('localhost:5639')
+	expect(getOriginHost('https://127.0.0.1:5639')).toBe('127.0.0.1:5639')
+	expect(getOriginHost('null')).toBeNull()
+	expect(getOriginHost(undefined)).toBeNull()
+	expect(getOriginHost('not-a-url')).toBeNull()
+})
+
+test('aligns when Codespaces rewrites Origin to localhost but X-Forwarded-Host stays public (aha)', () => {
+	expect(
+		shouldAlignLoopbackOriginHeaders({
+			deployed: false,
+			originHost: 'localhost:5639',
+			hostHeader: 'localhost:5639',
+			forwardedHostHeader: 'literate-lamp-975vggxqvvhp4jx-5639.app.github.dev',
+		}),
+	).toBe(true)
+})
+
+test('aligns localhost vs 127.0.0.1 Host mismatches on undeployed workshops', () => {
+	expect(
+		shouldAlignLoopbackOriginHeaders({
+			deployed: false,
+			originHost: '127.0.0.1:5639',
+			hostHeader: 'localhost:5639',
+			forwardedHostHeader: undefined,
+		}),
+	).toBe(true)
+})
+
+test('does not align deployed workshops (keep strict CSRF proxy behavior)', () => {
+	expect(
+		shouldAlignLoopbackOriginHeaders({
+			deployed: true,
+			originHost: 'localhost:5639',
+			hostHeader: 'localhost:5639',
+			forwardedHostHeader: 'workshop.example.com',
+		}),
+	).toBe(false)
+})
+
+test('does not align cross-site scanner Origins', () => {
+	expect(
+		shouldAlignLoopbackOriginHeaders({
+			deployed: false,
+			originHost: 'www.flixbus.com',
+			hostHeader: 'localhost:5639',
+			forwardedHostHeader: 'literate-lamp-975vggxqvvhp4jx-5639.app.github.dev',
+		}),
+	).toBe(false)
+})
+
+test('does not align when Origin already matches Host and there is no forwarded host', () => {
+	expect(
+		shouldAlignLoopbackOriginHeaders({
+			deployed: false,
+			originHost: 'localhost:5639',
+			hostHeader: 'localhost:5639',
+			forwardedHostHeader: undefined,
+		}),
+	).toBe(false)
+})
+
+test('middleware rewrites Host and drops X-Forwarded-Host for Codespaces loopback Origin', () => {
+	vi.stubGlobal('ENV', { EPICSHOP_DEPLOYED: false })
+	const req = {
+		headers: {
+			origin: 'http://localhost:5639',
+			host: 'localhost:5639',
+			'x-forwarded-host': 'literate-lamp-975vggxqvvhp4jx-5639.app.github.dev',
+		},
+	} as unknown as Request
+	const next = vi.fn()
+
+	alignLoopbackOriginHeaders(req, {} as Response, next)
+
+	expect(req.headers.host).toBe('localhost:5639')
+	expect(req.headers['x-forwarded-host']).toBeUndefined()
+	expect(next).toHaveBeenCalledOnce()
+	vi.unstubAllGlobals()
+})
+
+test('middleware leaves scanner requests untouched', () => {
+	vi.stubGlobal('ENV', { EPICSHOP_DEPLOYED: false })
+	const req = {
+		headers: {
+			origin: 'https://www.flixbus.com',
+			host: 'localhost:5639',
+			'x-forwarded-host': 'literate-lamp-975vggxqvvhp4jx-5639.app.github.dev',
+		},
+	} as unknown as Request
+	const next = vi.fn()
+
+	alignLoopbackOriginHeaders(req, {} as Response, next)
+
+	expect(req.headers.host).toBe('localhost:5639')
+	expect(req.headers['x-forwarded-host']).toBe(
+		'literate-lamp-975vggxqvvhp4jx-5639.app.github.dev',
+	)
+	expect(next).toHaveBeenCalledOnce()
+	vi.unstubAllGlobals()
+})

--- a/packages/workshop-app/tests/align-loopback-origin.test.ts
+++ b/packages/workshop-app/tests/align-loopback-origin.test.ts
@@ -2,6 +2,7 @@ import { type Request, type Response } from 'express'
 import { expect, test, vi } from 'vitest'
 import {
 	alignLoopbackOriginHeaders,
+	getHostPort,
 	getOriginHost,
 	isLoopbackHost,
 	shouldAlignLoopbackOriginHeaders,
@@ -26,6 +27,12 @@ test('parses Origin hosts and rejects invalid values', () => {
 	expect(getOriginHost('not-a-url')).toBeNull()
 })
 
+test('extracts ports for same-port loopback comparisons', () => {
+	expect(getHostPort('localhost:5639')).toBe('5639')
+	expect(getHostPort('127.0.0.1:5639')).toBe('5639')
+	expect(getHostPort('localhost:3000')).toBe('3000')
+})
+
 test('aligns when Codespaces rewrites Origin to localhost but X-Forwarded-Host stays public (aha)', () => {
 	expect(
 		shouldAlignLoopbackOriginHeaders({
@@ -37,7 +44,7 @@ test('aligns when Codespaces rewrites Origin to localhost but X-Forwarded-Host s
 	).toBe(true)
 })
 
-test('aligns localhost vs 127.0.0.1 Host mismatches on undeployed workshops', () => {
+test('aligns localhost vs 127.0.0.1 Host mismatches on the same port', () => {
 	expect(
 		shouldAlignLoopbackOriginHeaders({
 			deployed: false,
@@ -46,6 +53,25 @@ test('aligns localhost vs 127.0.0.1 Host mismatches on undeployed workshops', ()
 			forwardedHostHeader: undefined,
 		}),
 	).toBe(true)
+})
+
+test('does not align different loopback ports (cross-port CSRF bypass aha)', () => {
+	expect(
+		shouldAlignLoopbackOriginHeaders({
+			deployed: false,
+			originHost: 'localhost:3000',
+			hostHeader: 'localhost:5639',
+			forwardedHostHeader: undefined,
+		}),
+	).toBe(false)
+	expect(
+		shouldAlignLoopbackOriginHeaders({
+			deployed: false,
+			originHost: 'localhost:3000',
+			hostHeader: 'localhost:5639',
+			forwardedHostHeader: 'literate-lamp-975vggxqvvhp4jx-5639.app.github.dev',
+		}),
+	).toBe(false)
 })
 
 test('does not align deployed workshops (keep strict CSRF proxy behavior)', () => {
@@ -96,6 +122,27 @@ test('middleware rewrites Host and drops X-Forwarded-Host for Codespaces loopbac
 
 	expect(req.headers.host).toBe('localhost:5639')
 	expect(req.headers['x-forwarded-host']).toBeUndefined()
+	expect(next).toHaveBeenCalledOnce()
+	vi.unstubAllGlobals()
+})
+
+test('middleware leaves cross-port loopback requests untouched', () => {
+	vi.stubGlobal('ENV', { EPICSHOP_DEPLOYED: false })
+	const req = {
+		headers: {
+			origin: 'http://localhost:3000',
+			host: 'localhost:5639',
+			'x-forwarded-host': 'literate-lamp-975vggxqvvhp4jx-5639.app.github.dev',
+		},
+	} as unknown as Request
+	const next = vi.fn()
+
+	alignLoopbackOriginHeaders(req, {} as Response, next)
+
+	expect(req.headers.host).toBe('localhost:5639')
+	expect(req.headers['x-forwarded-host']).toBe(
+		'literate-lamp-975vggxqvvhp4jx-5639.app.github.dev',
+	)
 	expect(next).toHaveBeenCalledOnce()
 	vi.unstubAllGlobals()
 })

--- a/packages/workshop-app/tests/route-errors.test.ts
+++ b/packages/workshop-app/tests/route-errors.test.ts
@@ -57,8 +57,14 @@ test('does not treat a 500 route error response as a client error (server faults
 	expect(isClientErrorResponse(error)).toBe(false)
 })
 
-test('does not treat a plain Error as a client error response', () => {
+test('does not treat an unrelated plain Error as a client error response', () => {
 	expect(isClientErrorResponse(new Error('boom'))).toBe(false)
+})
+
+test('treats React Router CSRF Error("Bad Request") as a client error (aha)', () => {
+	// singleFetchAction catches the descriptive origin-mismatch error and
+	// reports this bare message through handleError while returning HTTP 400.
+	expect(isClientErrorResponse(new Error('Bad Request'))).toBe(true)
 })
 
 test('does not treat null or undefined as a client error response', () => {

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -10,6 +10,7 @@ import {
 	isProcessingPictureInPictureRequest,
 	isReactExtensionRenderLoopNoise,
 	isSessionStorageAccessDenied,
+	isUnexpectedServerErrorNoise,
 	processingPictureInPictureRequestMessage,
 } from '../app/utils/sentry-filters.ts'
 import { isServerEnvironmentNoise } from '../sentry-server-filters.js'
@@ -313,11 +314,44 @@ test('drops React render-loop fatals cascaded from addEL_hook extensions (aha)',
 	).toBe(false)
 })
 
+test('drops React Router opaque Unexpected Server Error client mirrors (aha)', () => {
+	expect(
+		isUnexpectedServerErrorNoise({
+			exception: {
+				values: [{ type: 'Error', value: 'Unexpected Server Error' }],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isUnexpectedServerErrorNoise({
+			exception: {
+				values: [
+					{ type: 'Error', value: 'Unexpected Server Error with detail' },
+				],
+			},
+		}),
+	).toBe(false)
+	expect(
+		isUnexpectedServerErrorNoise({
+			exception: {
+				values: [{ type: 'TypeError', value: 'Unexpected Server Error' }],
+			},
+		}),
+	).toBe(false)
+})
+
 test('isClientSentryNoise aggregates the client predicates', () => {
 	expect(
 		isClientSentryNoise({
 			exception: {
 				values: [{ type: 'AbortError', value: 'The operation was aborted.' }],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isClientSentryNoise({
+			exception: {
+				values: [{ type: 'Error', value: 'Unexpected Server Error' }],
 			},
 		}),
 	).toBe(true)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Root cause (EPICSHOP-6 + sibling EPICSHOP-G8):** React Router’s single-fetch CSRF check prefers `X-Forwarded-Host`. GitHub Codespaces rewrites browser `Origin` to `localhost:<port>` while leaving `X-Forwarded-Host` as `*.app.github.dev`, so legitimate POSTs (`/admin/notifications`, `/mark-onboarding-complete`, `/login`, `/set-playground`, …) get HTTP 400. Production sanitizes that to the opaque client `Error: Unexpected Server Error` (no stack). Same timestamp pairing confirms G8 is the server-side twin.
- **Product fix:** For undeployed workshops only, when `Origin` is loopback and disagrees with `Host` / `X-Forwarded-Host`, align those headers to the Origin host. Cross-site scanner Origins (e.g. `www.flixbus.com`) are unchanged and still rejected. Deployed workshops keep strict proxy CSRF behavior.
- **Reporting cleanup:** Treat React Router’s bare `Error("Bad Request")` from the CSRF guard as a client error in `handleError` (stops G8 noise). Filter client-side exact `Unexpected Server Error` mirrors (never actionable; real faults are reported server-side when they exist).

## Test plan

- [x] Unit tests for loopback host alignment (Codespaces + 127.0.0.1 vs localhost + scanner negative)
- [x] Unit tests for CSRF `Bad Request` handleError skip and client Unexpected Server Error filter
- [x] `npm run validate`

Sentry: [EPICSHOP-6](https://kent-c-dodds-tech-llc.sentry.io/issues/6735092039/) · sibling [EPICSHOP-G8](https://kent-c-dodds-tech-llc.sentry.io/issues/7541196415/)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8396884-16e8-4132-9c08-6e190cd196ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8396884-16e8-4132-9c08-6e190cd196ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

