### PR TITLE
fix: stop /account crash when auth exists without userinfo (EPICSHOP-FX)

### DIFF
--- a/packages/workshop-app/app/routes/_app+/account.tsx
+++ b/packages/workshop-app/app/routes/_app+/account.tsx
@@ -5,6 +5,7 @@ import {
 	requireAuthInfo,
 	setPreferences,
 } from '@epic-web/workshop-utils/db.server'
+import { getUserInfo } from '@epic-web/workshop-utils/epic-api.server'
 import { type SEOHandle } from '@nasa-gcn/remix-seo'
 import { redirect, Form, Link } from 'react-router'
 import { Button } from '#app/components/button.tsx'
@@ -16,7 +17,6 @@ import {
 import { SimpleTooltip } from '#app/components/ui/tooltip.tsx'
 import {
 	useOptionalDiscordMember,
-	useUser,
 	useUserHasAccess,
 } from '#app/components/user.tsx'
 import { useWorkshopConfig } from '#app/components/workshop-config.tsx'
@@ -30,7 +30,14 @@ export const handle: SEOHandle = {
 export async function loader({ request }: Route.LoaderArgs) {
 	ensureUndeployed()
 	await requireAuthInfo({ request })
-	return {}
+	// Auth tokens can exist while userinfo is unavailable (offline / API /
+	// expired token). Account UI needs userinfo, and root may not revalidate
+	// after a /login → /account redirect, so load it here instead of useUser().
+	const user = await getUserInfo({ request })
+	if (!user) {
+		throw redirect('/login')
+	}
+	return { user }
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -65,8 +72,8 @@ function useConnectDiscordURL() {
 	return `https://${host}/discord`
 }
 
-export default function Account() {
-	const user = useUser()
+export default function Account({ loaderData }: Route.ComponentProps) {
+	const { user } = loaderData
 	const config = useWorkshopConfig()
 	const discordMember = useOptionalDiscordMember()
 	const connectDiscordURL = useConnectDiscordURL()

--- a/packages/workshop-app/app/routes/_app+/login.tsx
+++ b/packages/workshop-app/app/routes/_app+/login.tsx
@@ -1,4 +1,4 @@
-import { getAuthInfo } from '@epic-web/workshop-utils/db.server'
+import { getUserInfo } from '@epic-web/workshop-utils/epic-api.server'
 import { type SEOHandle } from '@nasa-gcn/remix-seo'
 import { useEffect, useState } from 'react'
 import {
@@ -24,8 +24,10 @@ export const handle: SEOHandle = {
 
 export async function loader() {
 	ensureUndeployed()
-	const isAuthenticated = Boolean(await getAuthInfo())
-	if (isAuthenticated) throw redirect('/account')
+	// Require userinfo, not just local auth tokens. Tokens-without-userinfo used
+	// to redirect to /account, where useUser() threw (EPICSHOP-FX).
+	const user = await getUserInfo()
+	if (user) throw redirect('/account')
 	return {}
 }
 

--- a/packages/workshop-app/tests/account-login-auth.test.ts
+++ b/packages/workshop-app/tests/account-login-auth.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+vi.mock('@epic-web/workshop-utils/db.server', () => ({
+	requireAuthInfo: vi.fn(),
+	logout: vi.fn(),
+	setPreferences: vi.fn(),
+}))
+vi.mock('@epic-web/workshop-utils/cache.server', () => ({
+	deleteCache: vi.fn(),
+}))
+vi.mock('@epic-web/workshop-utils/epic-api.server', () => ({
+	getUserInfo: vi.fn(),
+}))
+vi.mock('#app/utils/misc.tsx', () => ({
+	ensureUndeployed: vi.fn(),
+	cn: (...args: Array<unknown>) => args.filter(Boolean).join(' '),
+}))
+vi.mock('#app/utils/auth.server.ts', () => ({
+	registerDevice: vi.fn(),
+}))
+
+const { requireAuthInfo } = await import('@epic-web/workshop-utils/db.server')
+const { getUserInfo } = await import('@epic-web/workshop-utils/epic-api.server')
+const { loader: accountLoader } =
+	await import('../app/routes/_app+/account.tsx')
+const { loader: loginLoader } = await import('../app/routes/_app+/login.tsx')
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+async function getRedirect(promise: Promise<unknown>) {
+	const error = await promise.catch((value: unknown) => value)
+	expect(error).toBeInstanceOf(Response)
+	return error as Response
+}
+
+test('account loader redirects to login when auth tokens exist but userinfo is unavailable (aha: EPICSHOP-FX)', async () => {
+	vi.mocked(requireAuthInfo).mockResolvedValue({
+		id: 'user-1',
+		tokenSet: { access_token: 'token' },
+		email: 'person@example.com',
+	} as never)
+	vi.mocked(getUserInfo).mockResolvedValue(null)
+
+	const response = await getRedirect(
+		accountLoader({
+			request: new Request('http://localhost/account'),
+		} as Parameters<typeof accountLoader>[0]),
+	)
+
+	expect(response.status).toBe(302)
+	expect(response.headers.get('Location')).toBe('/login')
+})
+
+test('account loader returns userinfo when available', async () => {
+	const user = {
+		id: 'user-1',
+		email: 'person@example.com',
+		name: 'Person',
+	}
+	vi.mocked(requireAuthInfo).mockResolvedValue({
+		id: 'user-1',
+		tokenSet: { access_token: 'token' },
+		email: 'person@example.com',
+	} as never)
+	vi.mocked(getUserInfo).mockResolvedValue(user as never)
+
+	await expect(
+		accountLoader({
+			request: new Request('http://localhost/account'),
+		} as Parameters<typeof accountLoader>[0]),
+	).resolves.toEqual({ user })
+})
+
+test('login loader does not redirect to account when auth tokens exist without userinfo (aha: EPICSHOP-FX)', async () => {
+	vi.mocked(getUserInfo).mockResolvedValue(null)
+
+	await expect(loginLoader()).resolves.toEqual({})
+})
+
+test('login loader redirects to account when userinfo is available', async () => {
+	vi.mocked(getUserInfo).mockResolvedValue({
+		id: 'user-1',
+		email: 'person@example.com',
+		name: 'Person',
+	} as never)
+
+	const response = await getRedirect(loginLoader())
+
+	expect(response.status).toBe(302)
+	expect(response.headers.get('Location')).toBe('/account')
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [EPICSHOP-FX](https://kent-c-dodds-tech-llc.sentry.io/issues/7506028708/): `useUser requires a user` crash on `/account` after clicking Login.

### Root cause

Local auth tokens can exist while `getUserInfo()` returns `null` (offline / expired token / API failure). In that state:

1. Root `user` is null, so the UI shows the Login banner
2. `/login` loader treated `getAuthInfo()` as enough and redirected to `/account` (React Router `.data` 202)
3. `/account` loader only called `requireAuthInfo()` (tokens OK) and the component called `useUser()` from root data
4. Root often did not revalidate on that redirect chain, so `useUser()` threw

### Fix

- `/account` loader loads `getUserInfo()` and redirects to `/login` when unavailable; component uses loader `user` instead of `useUser()`
- `/login` loader redirects to `/account` only when userinfo is available (not merely local tokens)
- Unit tests cover the auth-without-userinfo path

### Status

Merged to `main` as `d09a77c9783d517b89301c92794ba453f2a30339`. Sentry issue resolved in that commit. Sibling unresolved issues (EPICSHOP-H9, EPICSHOP-6) do not share this root cause.

## Test plan

- [x] `vitest run packages/workshop-app/tests/account-login-auth.test.ts`
- [x] `npm run validate`
- [x] CI green on PR #637

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd1a9342-8ef6-4806-8cb3-e2b70333f9c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd1a9342-8ef6-4806-8cb3-e2b70333f9c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

