### PR TITLE
fix: filter stale React Router single-fetch routeId Sentry noise (EPICSHOP-58)

### DIFF
--- a/packages/workshop-app/app/utils/monitoring.client.ts
+++ b/packages/workshop-app/app/utils/monitoring.client.ts
@@ -140,6 +140,7 @@ export function init() {
 			/Failed to fetch/i,
 			/NetworkError when attempting to fetch resource/i,
 			/^Load failed/i,
+			/No result found for routeId /i,
 		],
 		beforeSend(event) {
 			if (isClientSentryNoise(event)) return null

--- a/packages/workshop-app/app/utils/sentry-filters.ts
+++ b/packages/workshop-app/app/utils/sentry-filters.ts
@@ -69,6 +69,18 @@ export function isAbortErrorNoise(event: SentryEventWithException) {
 }
 
 /**
+ * React Router single-fetch throws when the client asks for a routeId that
+ * isn't in the server payload — typically a tab left open across a local
+ * restart or a deployed workshop update (client/server route-manifest skew).
+ * Not an actionable product defect; a hard refresh recovers.
+ */
+export function isStaleRouteResultNoise(event: SentryEventWithException) {
+	return getExceptionValues(event).some((value) =>
+		/No result found for routeId /i.test(exceptionValueText(value)),
+	)
+}
+
+/**
  * Browser/network blips while the local (or hosted) workshop server flaps,
  * the tab sleeps, or the learner's connection drops mid-fetch.
  */
@@ -240,6 +252,7 @@ export function isClientSentryNoise(event: SentryEventWithException) {
 	return (
 		isProcessingPictureInPictureRequest(event) ||
 		isAbortErrorNoise(event) ||
+		isStaleRouteResultNoise(event) ||
 		isBrowserNetworkNoise(event) ||
 		isSessionStorageAccessDenied(event) ||
 		isCrossOriginSecurityNoise(event) ||

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -10,6 +10,7 @@ import {
 	isProcessingPictureInPictureRequest,
 	isReactExtensionRenderLoopNoise,
 	isSessionStorageAccessDenied,
+	isStaleRouteResultNoise,
 	processingPictureInPictureRequestMessage,
 } from '../app/utils/sentry-filters.ts'
 import { isServerEnvironmentNoise } from '../sentry-server-filters.js'
@@ -80,6 +81,58 @@ test('drops AbortError navigation/fetch aborts (aha)', () => {
 		isAbortErrorNoise({
 			exception: {
 				values: [{ type: 'Error', value: 'Fetch is aborted' }],
+			},
+		}),
+	).toBe(true)
+})
+
+test('drops stale single-fetch routeId misses after restart/deploy (aha)', () => {
+	expect(
+		isStaleRouteResultNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'No result found for routeId "routes/$"',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isStaleRouteResultNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value:
+							'No result found for routeId "routes/_app+/exercise+/$exerciseNumber"',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isStaleRouteResultNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Invalid response found for routeId "routes/_app+/index"',
+					},
+				],
+			},
+		}),
+	).toBe(false)
+	expect(
+		isClientSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'No result found for routeId "routes/_app+/index"',
+					},
+				],
 			},
 		}),
 	).toBe(true)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

React Router’s single-fetch path throws `Error: No result found for routeId "…"` from `unwrapSingleFetchResult` when the client asks for a route that isn’t in the server payload. That shows up when a learner (or hosted-workshop visitor) keeps a tab open across a local server restart or a deploy — client/server route-manifest skew, not an actionable product bug. A hard refresh recovers.

This PR drops that specific signature from client Sentry reporting (`beforeSend` + `ignoreErrors`) and covers EPICSHOP-58 plus the same-family backfill issues (EPICSHOP-GC, EPICSHOP-FZ, EPICSHOP-F9).

## Changes

- Add `isStaleRouteResultNoise` matching `/No result found for routeId /i`
- Wire it into `isClientSentryNoise` and `ignoreErrors`
- Unit tests for the known routeId variants and a non-match (`Invalid response found for routeId`)

## Risk

Low — filter-only, narrow signature, no runtime behavior change for learners.

## Test plan

- [x] `vitest run packages/workshop-app/tests/sentry-filters.test.ts`
- [x] `npm run test` (pre-push)
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb98f5db-8412-4834-810c-00f6c35e6ac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb98f5db-8412-4834-810c-00f6c35e6ac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

