### PR TITLE
fix: percent-encode catchall Location headers (EPICSHOP-HA)

### DIFF
--- a/packages/workshop-app/app/routes/$.tsx
+++ b/packages/workshop-app/app/routes/$.tsx
@@ -18,10 +18,13 @@ export async function loader({ params }: Route.LoaderArgs) {
 	const [firstSegment] = splat?.split('/') ?? []
 	if (firstSegment && /^\d+$/.test(firstSegment)) {
 		const newPath = `/exercise/${splat}`
+		// Response headers are ByteStrings (code points ≤ 255). React Router
+		// gives decoded splat params, so a probe like `/1/%EF%BD%B0oast.me`
+		// would put U+FF70 into Location and throw TypeError (EPICSHOP-HA).
 		return new Response(null, {
 			status: 302,
 			headers: {
-				Location: newPath,
+				Location: encodeURI(newPath),
 			},
 		})
 	}

--- a/packages/workshop-app/tests/catchall-route.test.ts
+++ b/packages/workshop-app/tests/catchall-route.test.ts
@@ -28,6 +28,16 @@ test('redirects a zero-padded exercise path including the step type', async () =
 	expect(response.headers.get('Location')).toBe('/exercise/01/02/problem')
 })
 
+test('percent-encodes non-ASCII Location values so Response headers stay ByteString-safe (aha: EPICSHOP-HA)', async () => {
+	const unicodeMark = '\uFF70' // HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
+	const response = await callLoader(`1/${unicodeMark}oast.me`)
+
+	expect(response.status).toBe(302)
+	expect(response.headers.get('Location')).toBe(
+		`/exercise/1/${encodeURIComponent(unicodeMark)}oast.me`,
+	)
+})
+
 test('404s a non-numeric first segment', async () => {
 	await expect(callLoader('foo/bar')).rejects.toMatchObject({ status: 404 })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [EPICSHOP-HA](https://kent-c-dodds-tech-llc.sentry.io/issues/7637416814/) (`TypeError: Cannot convert argument to a ByteString…`) fired on scanner probes like `GET //%EF%BD%B0oast.me` against a workshop still on epicshop **6.90.13**.

### Root cause

1. Pre-`#630` catchall treated `Number('')` as a valid exercise number, so `//…` redirected to `/exercise//…` with a `Location` header.
2. Even on current main, a path like `/1/<non-ASCII>` still builds `Location: /exercise/1/<non-ASCII>`. Response headers must be ByteStrings (code points ≤ 255), so undici throws.

`#630` / `v6.90.17+` already rejects protocol-relative `//` paths and tightens the numeric check. This PR closes the residual hole by `encodeURI`-ing the catchall `Location` value (same ByteString lesson as the toast/PE fixes).

### Test plan

- [x] `vitest run packages/workshop-app/tests/catchall-route.test.ts` — includes EPICSHOP-HA aha case
- [x] `npm run validate`
- [x] CI green; squash-merged as `4bbc980e`

Risk: **low** — isolated redirect header encoding with unit coverage. Merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b916b5df-6c15-44da-ba4d-dbeb664e2e14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b916b5df-6c15-44da-ba4d-dbeb664e2e14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

