### PR TITLE
fix: skip document-request CSRF abort Errors in handleError (EPICSHOP-HB)

### DIFF
--- a/packages/workshop-app/app/utils/route-errors.ts
+++ b/packages/workshop-app/app/utils/route-errors.ts
@@ -5,10 +5,29 @@ import { isRouteErrorResponse } from 'react-router'
 // even though it has already answered the request with that 4xx status, so
 // they are client mistakes, not server faults.
 //
-// The single-fetch CSRF guard is the other case: it catches a descriptive
+// CSRF guards are the other case. Single-fetch catches a descriptive
 // origin-mismatch Error and re-reports a bare Error("Bad Request") through
-// handleError while already answering with HTTP 400. That is not a server
-// fault (Codespaces proxy mismatch or a cross-site probe).
+// handleError while already answering with HTTP 400. Document POSTs pass the
+// descriptive Error into handleError before returning 400. Neither is a
+// server fault (Codespaces proxy mismatch or a cross-site probe).
+function isReactRouterCsrfClientError(error: Error) {
+	const { message } = error
+	if (message === 'Bad Request') return true
+	if (message === '`origin` header is not a valid URL. Aborting the action.') {
+		return true
+	}
+	if (
+		message ===
+		'`x-forwarded-host` or `host` headers are not provided. One of these is needed to compare the `origin` header from a forwarded action request. Aborting the action.'
+	) {
+		return true
+	}
+	// host.type is "host" or "x-forwarded-host"
+	return /^(?:host|x-forwarded-host) header does not match `origin` header from a forwarded action request\. Aborting the action\.$/.test(
+		message,
+	)
+}
+
 export function isClientErrorResponse(error: unknown) {
 	if (
 		isRouteErrorResponse(error) &&
@@ -17,5 +36,5 @@ export function isClientErrorResponse(error: unknown) {
 	) {
 		return true
 	}
-	return error instanceof Error && error.message === 'Bad Request'
+	return error instanceof Error && isReactRouterCsrfClientError(error)
 }

--- a/packages/workshop-app/tests/route-errors.test.ts
+++ b/packages/workshop-app/tests/route-errors.test.ts
@@ -67,6 +67,45 @@ test('treats React Router CSRF Error("Bad Request") as a client error (aha)', ()
 	expect(isClientErrorResponse(new Error('Bad Request'))).toBe(true)
 })
 
+test('treats React Router document-request CSRF abort Errors as client errors (aha)', () => {
+	// handleDocumentRequest passes the descriptive throwIfPotentialCSRFAttack
+	// Error into handleError before returning HTTP 400 (EPICSHOP-HB).
+	expect(
+		isClientErrorResponse(
+			new Error('`origin` header is not a valid URL. Aborting the action.'),
+		),
+	).toBe(true)
+	expect(
+		isClientErrorResponse(
+			new Error(
+				'host header does not match `origin` header from a forwarded action request. Aborting the action.',
+			),
+		),
+	).toBe(true)
+	expect(
+		isClientErrorResponse(
+			new Error(
+				'x-forwarded-host header does not match `origin` header from a forwarded action request. Aborting the action.',
+			),
+		),
+	).toBe(true)
+	expect(
+		isClientErrorResponse(
+			new Error(
+				'`x-forwarded-host` or `host` headers are not provided. One of these is needed to compare the `origin` header from a forwarded action request. Aborting the action.',
+			),
+		),
+	).toBe(true)
+})
+
+test('does not treat unrelated Aborting-the-action text as a client CSRF error', () => {
+	expect(
+		isClientErrorResponse(
+			new Error('Something went wrong. Aborting the action.'),
+		),
+	).toBe(false)
+})
+
 test('does not treat null or undefined as a client error response', () => {
 	expect(isClientErrorResponse(null)).toBe(false)
 	expect(isClientErrorResponse(undefined)).toBe(false)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Root cause (EPICSHOP-HB):** React Router’s `handleDocumentRequest` CSRF guard calls `handleError` with the descriptive `throwIfPotentialCSRFAttack` Error (e.g. `` `origin` header is not a valid URL. Aborting the action. ``) before returning HTTP 400. The single-fetch path already rewrites that to bare `Error("Bad Request")`, which we skip after EPICSHOP-6/G8 — document POSTs still reported the descriptive message.
- **Trigger:** Cross-site / scanner `POST` with an invalid `Origin` (event URL looked like a JSP probe on a deployed workshop). CSRF correctly rejects; Sentry should not treat it as a server fault.
- **Fix:** Extend `isClientErrorResponse` to recognize React Router’s document-path CSRF abort messages so `handleError` skips them the same way as `Error("Bad Request")`.

## Test plan

- [x] Unit tests for all three descriptive CSRF abort messages + negative case
- [x] Existing `Bad Request` / 4xx ErrorResponse coverage still passes
- [x] `npm run validate`
- [x] CI green; squash-merged

Sentry: [EPICSHOP-HB](https://kent-c-dodds-tech-llc.sentry.io/issues/7637532482/) — resolved in `82256e67a6991136375a55f1228853371bd8995d`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b61d26c-b248-4932-bd81-ad4fc2dba875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b61d26c-b248-4932-bd81-ad4fc2dba875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

