### PR TITLE
fix: make workshop deploy CI green without losing confidence

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -26,7 +26,12 @@ fan-out:
 - It lengthens `epicshop/fly.yaml` HTTP/TCP health-check grace periods when
   present
 - Package/fly updates are committed and pushed separately from workflow file
-  changes, so a missing `workflow` PAT scope cannot block version bumps
+  changes when the token lacks `workflow` scope, so version bumps are not
+  blocked; with `workflow` scope they share one commit to avoid double deploys
+- Workshop deploy CI uses `SKIP_PLAYGROUND=true` during setup so typecheck/lint
+  validate the workshop itself rather than a problem playground app, runs
+  solution tests via `epicshop/test.js ..s` when present, and still requires a
+  successful Fly deploy plus HTTP healthcheck on main
 
 ### `WORKSHOP_UPDATE_TOKEN` requirements
 

--- a/other/update-workshops/canonical/deploy.yml
+++ b/other/update-workshops/canonical/deploy.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   setup:
     name: 🔧 Setup
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -25,29 +25,51 @@ jobs:
         with:
           node-version: 26
 
+      # SKIP_PLAYGROUND keeps typecheck/lint meaningful: problem playground apps
+      # intentionally fail solution tests/types, which would create false CI red.
       - name: ▶️ Add repo
-        run: |
-          npx --yes epicshop@latest add ${{ github.event.repository.name }}#${{ github.head_ref || github.ref_name }} ./workshop
         env:
           # Kept getting npm ECOMPROMISED errors on windows. This fixed it.
           npm_config_cache: ${{ runner.temp }}/npm-cache
           SKIP_PLAYWRIGHT: true
+          SKIP_PLAYGROUND: true
+        run: |
+          set -euo pipefail
+          attempt=1
+          max_attempts=3
+          delay_seconds=20
+          while true; do
+            echo "::group::epicshop add attempt ${attempt}/${max_attempts}"
+            set +e
+            npx --yes epicshop@latest add ${{ github.event.repository.name }}#${{ github.head_ref || github.ref_name }} ./workshop
+            status=$?
+            set -e
+            echo "::endgroup::"
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "epicshop add failed after ${max_attempts} attempts" >&2
+              exit "$status"
+            fi
+            echo "epicshop add failed (exit ${status}); retrying in ${delay_seconds}s..."
+            sleep "$delay_seconds"
+            delay_seconds=$((delay_seconds * 2))
+            attempt=$((attempt + 1))
+          done
 
       - name: ʦ TypeScript
         run: npm run typecheck
         working-directory: ./workshop
 
-      - name: ⬣ Oxlint
+      - name: ⬣ Lint
         run: npm run lint
         working-directory: ./workshop
 
   tests:
     name: 🧪 Test
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
-    # Use continue-on-error to ensure this job doesn't fail the workflow
-    continue-on-error: true
-
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
@@ -60,9 +82,15 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
-      - name: 🧪 Run tests
-        id: run_tests
-        run: node ./epicshop/test.ts ..s
+      # Workshops ship epicshop/test.js (not .ts). `..s` runs solution apps only.
+      - name: 🧪 Run solution tests
+        run: |
+          set -euo pipefail
+          if [ -f ./epicshop/test.js ]; then
+            node ./epicshop/test.js ..s
+          else
+            echo "No epicshop/test.js in this workshop; skipping solution-app test runner."
+          fi
 
   deploy:
     name: 🚀 Deploy

--- a/other/update-workshops/index.js
+++ b/other/update-workshops/index.js
@@ -786,35 +786,69 @@ async function updateWorkshopRepo(
 		let pushedAnything = false
 		let workflowWarning = null
 
-		// Push package/fly updates first so a missing `workflow` PAT scope cannot
-		// block the primary version bump.
 		const nonWorkflowCommitMessage = changed
 			? 'chore: update epicshop'
 			: 'chore: harden fly health checks'
-		const nonWorkflowPush = await stageCommitAndPush({
-			cwd: tempDir,
-			repoName,
-			files: nonWorkflowFiles,
-			commitMessage: nonWorkflowCommitMessage,
-		})
-		pushedAnything = pushedAnything || nonWorkflowPush.pushed
+		const combinedCommitMessage = changed
+			? 'chore: update epicshop'
+			: 'chore: harden fly deploy workflow'
 
-		if (workflowFiles.length > 0) {
+		// When the token can update workflow files, prefer one commit/push so each
+		// workshop only triggers a single deploy. Otherwise keep package/fly
+		// updates unblocked by pushing them separately from workflow files.
+		let useSplitPush = !syncWorkflows
+		if (syncWorkflows) {
 			try {
-				const workflowPush = await stageCommitAndPush({
+				const combinedPush = await stageCommitAndPush({
 					cwd: tempDir,
 					repoName,
-					files: workflowFiles,
-					commitMessage: 'chore: harden fly deploy workflow',
+					files: [...nonWorkflowFiles, ...workflowFiles],
+					commitMessage: combinedCommitMessage,
 				})
-				pushedAnything = pushedAnything || workflowPush.pushed
+				pushedAnything = combinedPush.pushed
 			} catch (error) {
-				if (!isWorkflowScopeError(error)) throw error
-				workflowWarning = workflowScopeHint()
-				console.error(
-					`⚠️  ${repoName} - could not push ${DEPLOY_WORKFLOW_PATH}: token lacks workflow scope`,
+				if (!isWorkflowScopeError(error) || nonWorkflowFiles.length === 0) {
+					throw error
+				}
+				// Combined commit was rejected; undo the commit but keep the file
+				// edits so we can push package/fly changes without the workflow file.
+				console.warn(
+					`⚠️  ${repoName} - combined push rejected for workflow scope; retrying package/fly only`,
 				)
-				console.error(`   ${workflowWarning}`)
+				await execa('git', ['reset', '--mixed', 'HEAD~1'], {
+					cwd: tempDir,
+					env: getGitEnv(),
+				})
+				useSplitPush = true
+			}
+		}
+
+		if (useSplitPush) {
+			const nonWorkflowPush = await stageCommitAndPush({
+				cwd: tempDir,
+				repoName,
+				files: nonWorkflowFiles,
+				commitMessage: nonWorkflowCommitMessage,
+			})
+			pushedAnything = pushedAnything || nonWorkflowPush.pushed
+
+			if (workflowFiles.length > 0) {
+				try {
+					const workflowPush = await stageCommitAndPush({
+						cwd: tempDir,
+						repoName,
+						files: workflowFiles,
+						commitMessage: 'chore: harden fly deploy workflow',
+					})
+					pushedAnything = pushedAnything || workflowPush.pushed
+				} catch (error) {
+					if (!isWorkflowScopeError(error)) throw error
+					workflowWarning = workflowScopeHint()
+					console.error(
+						`⚠️  ${repoName} - could not push ${DEPLOY_WORKFLOW_PATH}: token lacks workflow scope`,
+					)
+					console.error(`   ${workflowWarning}`)
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After Update Workshops synced the canonical deploy workflow, many workshop Actions runs went red even though Fly deploys and healthchecks succeeded.

Root causes in the canonical workflow:

1. **Dropped `SKIP_PLAYGROUND=true`** — setup copied the first problem app into `playground`, then typecheck failed on intentional problem/solution mismatches
2. **Wrong test entrypoint** — ran `epicshop/test.ts` but workshops ship `epicshop/test.js`
3. **Tests were `continue-on-error`** — so solution tests didn’t gate confidence when they should

## Changes

- Restore `SKIP_PLAYGROUND` for setup typecheck/lint
- Run required solution tests with `node ./epicshop/test.js ..s` when present (skip cleanly otherwise)
- Retry flaky `epicshop add` network failures
- Keep hardened Fly deploy retries + post-deploy HTTP healthcheck as the production gate
- Prefer a single updater commit/push when the token can update workflow files (avoids double deploys)

## Test plan

- [x] `npm test` in `other/update-workshops`
- [ ] Merge and re-run Update Workshops so workshops pick up the fixed validate.yml
- [ ] Confirm a previously-red workshop (e.g. structured-data) goes green on Setup + Test while Deploy/health still required
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f587aac3-129b-4452-bd5e-6e4037d6e099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f587aac3-129b-4452-bd5e-6e4037d6e099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

