### PR TITLE
fix: run workshop epicshop add retry loop with bash on Windows

### DIFF
--- a/other/update-workshops/canonical/deploy.yml
+++ b/other/update-workshops/canonical/deploy.yml
@@ -16,6 +16,7 @@ jobs:
     name: 🔧 Setup
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -27,7 +28,10 @@ jobs:
 
       # SKIP_PLAYGROUND keeps typecheck/lint meaningful: problem playground apps
       # intentionally fail solution tests/types, which would create false CI red.
+      # Use bash explicitly: Windows runners default to PowerShell, which cannot
+      # parse this retry loop.
       - name: ▶️ Add repo
+        shell: bash
         env:
           # Kept getting npm ECOMPROMISED errors on windows. This fixed it.
           npm_config_cache: ${{ runner.temp }}/npm-cache


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #643. Workshop Setup still failed on Windows because the new `epicshop add` retry loop is bash, and Windows runners default to PowerShell (`Missing opening '(' after keyword 'while'`). That failed the Windows matrix leg, and default `fail-fast` cancelled ubuntu/macos even though Test + Deploy were already green.

## Changes

- Force `shell: bash` on the Add repo step
- Set `strategy.fail-fast: false` so one OS failure does not cancel the others

## Test plan

- [ ] Merge and re-run Update Workshops
- [ ] Confirm Setup passes on windows/mac/ubuntu for a previously red workshop (e.g. structured-data)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f587aac3-129b-4452-bd5e-6e4037d6e099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f587aac3-129b-4452-bd5e-6e4037d6e099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

