### PR TITLE
Harden shared workshop setup and test CI

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -29,9 +29,11 @@ fan-out:
   changes when the token lacks `workflow` scope, so version bumps are not
   blocked; with `workflow` scope they share one commit to avoid double deploys
 - Workshop deploy CI uses `SKIP_PLAYGROUND=true` during setup so typecheck/lint
-  validate the workshop itself rather than a problem playground app, runs
-  solution tests via `epicshop/test.js ..s` when present, and still requires a
-  successful Fly deploy plus HTTP healthcheck on main
+  validate the workshop itself rather than a problem playground app, gives large
+  lint runs an 8 GB Node heap, installs Chromium and generates a Prisma client
+  when a schema is present before running solution tests via
+  `epicshop/test.js ..s`, and still requires a successful Fly deploy plus HTTP
+  healthcheck on main
 
 ### `WORKSHOP_UPDATE_TOKEN` requirements
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,8 +30,8 @@ fan-out:
   blocked; with `workflow` scope they share one commit to avoid double deploys
 - Workshop deploy CI uses `SKIP_PLAYGROUND=true` during setup so typecheck/lint
   validate the workshop itself rather than a problem playground app, gives large
-  lint runs an 8 GB Node heap, installs Chromium and generates a Prisma client
-  when a schema is present before running solution tests via
+  lint runs an 8 GB Node heap, installs Chromium and generates Prisma clients
+  for solution apps that have schemas before running solution tests via
   `epicshop/test.js ..s`, and still requires a successful Fly deploy plus HTTP
   healthcheck on main
 

--- a/other/update-workshops/canonical/deploy.yml
+++ b/other/update-workshops/canonical/deploy.yml
@@ -69,6 +69,8 @@ jobs:
       - name: ⬣ Lint
         run: npm run lint
         working-directory: ./workshop
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
 
   tests:
     name: 🧪 Test
@@ -85,6 +87,18 @@ jobs:
 
       - name: 📦 Install dependencies
         run: npm ci
+
+      - name: 🎭 Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: ◭ Generate Prisma client
+        run: |
+          set -euo pipefail
+          if [ -f ./prisma/schema.prisma ]; then
+            npx prisma generate
+          else
+            echo "No prisma/schema.prisma in this workshop; skipping Prisma client generation."
+          fi
 
       # Workshops ship epicshop/test.js (not .ts). `..s` runs solution apps only.
       - name: 🧪 Run solution tests

--- a/other/update-workshops/canonical/deploy.yml
+++ b/other/update-workshops/canonical/deploy.yml
@@ -89,16 +89,25 @@ jobs:
         run: npm ci
 
       - name: 🎭 Install Playwright browser
+        if: ${{ hashFiles('epicshop/test.js') != '' }}
         run: npx playwright install --with-deps chromium
 
-      - name: ◭ Generate Prisma client
+      - name: ◭ Generate Prisma clients
+        if: ${{ hashFiles('epicshop/test.js') != '' }}
         run: |
           set -euo pipefail
-          if [ -f ./prisma/schema.prisma ]; then
-            npx prisma generate
-          else
-            echo "No prisma/schema.prisma in this workshop; skipping Prisma client generation."
+          shopt -s globstar nullglob
+          schemas=(./exercises/**/*.solution.*/prisma/schema.prisma)
+          if [ "${#schemas[@]}" -eq 0 ]; then
+            echo "No solution-app Prisma schemas found; skipping Prisma client generation."
+            exit 0
           fi
+          for schema in "${schemas[@]}"; do
+            app_dir="${schema%/prisma/schema.prisma}"
+            echo "::group::prisma generate in ${app_dir}"
+            (cd "$app_dir" && npx prisma generate)
+            echo "::endgroup::"
+          done
 
       # Workshops ship epicshop/test.js (not .ts). `..s` runs solution apps only.
       - name: 🧪 Run solution tests

--- a/packages/workshop-utils/src/apps.server.ts
+++ b/packages/workshop-utils/src/apps.server.ts
@@ -287,6 +287,11 @@ export function isExtraApp(app: any): app is ExtraApp {
 	return isApp(app) && app.type === 'extra'
 }
 
+/**
+ * @deprecated Example apps were renamed to extra apps. Use {@link isExtraApp}.
+ */
+export const isExampleApp = isExtraApp
+
 export function isExerciseStepApp(app: any): app is ExerciseStepApp {
 	return isProblemApp(app) || isSolutionApp(app)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- install Chromium before shared workshop solution tests
- generate Prisma clients inside every solution workspace that owns a schema
- skip browser/Prisma preparation entirely when a workshop has no `epicshop/test.js`
- give large workshop lint runs an 8 GB Node heap
- restore `isExampleApp` as a deprecated compatibility alias for `isExtraApp`
- document the shared CI safeguards

## Confidence preserved
- solution tests still run whenever `epicshop/test.js` exists
- deploy and post-deploy Fly health checks remain required on main

## Validation
- `npx nx run @epic-web/workshop-utils:test` — 108 tests passed
- built package export identity check — `isExampleApp === isExtraApp`
- `npm run validate` — passed
- pre-commit lint, typecheck, and build — passed on both commits
- live `full-stack-testing` repository inspection confirms Prisma schemas are nested under `*.solution.*` workspaces

`npm run format:check` reports 17 pre-existing formatting differences in unrelated workshop-app files; this PR's touched files were formatted by the pre-commit hook.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c18ff62a-c7bd-4447-aa68-557539cbccba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c18ff62a-c7bd-4447-aa68-557539cbccba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

