### PR TITLE
Fix canonical workshop typecheck setup

### DIFF
--- a/other/update-workshops/canonical/deploy.yml
+++ b/other/update-workshops/canonical/deploy.yml
@@ -62,8 +62,17 @@ jobs:
             attempt=$((attempt + 1))
           done
 
+      # Some workshops generate React Router route types and Prisma clients for
+      # their exercise apps here. Generate them before the root project-reference
+      # typecheck, while allowing older workshops without this script to proceed.
+      - name: ⚙️ Generate app artifacts
+        run: npm run generate --if-present
+        working-directory: ./workshop
+
+      # Not every workshop has TypeScript. `--if-present` skips only a missing
+      # script; npm still returns a failure when an existing typecheck fails.
       - name: ʦ TypeScript
-        run: npm run typecheck
+        run: npm run typecheck --if-present
         working-directory: ./workshop
 
       - name: ⬣ Lint

--- a/other/update-workshops/helpers.test.js
+++ b/other/update-workshops/helpers.test.js
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
 	canUpdateWorkflowFiles,
 	isWorkflowScopeError,
@@ -6,6 +9,8 @@ import {
 	partitionFilesByWorkflow,
 	workflowScopeHint,
 } from './helpers.js'
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url))
 
 assert.equal(parseOAuthScopes(null), null)
 assert.equal(parseOAuthScopes(undefined), null)
@@ -49,5 +54,24 @@ assert.deepEqual(
 
 assert.match(workflowScopeHint(), /workflow/)
 assert.match(workflowScopeHint(), /WORKSHOP_UPDATE_TOKEN/)
+
+const canonicalDeployWorkflow = fs.readFileSync(
+	path.join(currentDirectory, 'canonical', 'deploy.yml'),
+	'utf8',
+)
+const generateCommand = 'npm run generate --if-present'
+const typecheckCommand = 'npm run typecheck --if-present'
+
+// Generate app artifacts before checking project references (aha).
+assert.ok(canonicalDeployWorkflow.includes(generateCommand))
+assert.ok(canonicalDeployWorkflow.includes(typecheckCommand))
+assert.ok(
+	canonicalDeployWorkflow.indexOf(generateCommand) <
+		canonicalDeployWorkflow.indexOf(typecheckCommand),
+)
+assert.doesNotMatch(
+	canonicalDeployWorkflow,
+	/run: npm run typecheck(?:\r?\n|$)/,
+)
 
 console.log('helpers.test.js: all assertions passed')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- generate optional workshop app artifacts before root TypeScript validation
- skip typecheck only when a workshop has no `typecheck` script
- protect command ordering and failure semantics with a regression test

## Context
Follow-up to #645 for failures in `react-and-the-vanishing-network` and `react-e2e-testing-with-playwright`.

## Validation
- pre-commit validation passed (format, lint, typecheck, build)
- pre-push tests passed (36 files, 279 tests)
- canonical workflow assertions passed
- live `epicshop add` of `react-e2e-testing-with-playwright` followed by generation removed the reported missing route types and Prisma exports; the existing typecheck still returned nonzero for unrelated genuine project errors, confirming failures are not masked
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be4ab941-d56d-4e1e-b0fa-3895ea7b1e55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be4ab941-d56d-4e1e-b0fa-3895ea7b1e55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

