### PR TITLE
Increase canonical workshop test timeout

### DIFF
--- a/other/update-workshops/canonical/deploy.yml
+++ b/other/update-workshops/canonical/deploy.yml
@@ -83,7 +83,8 @@ jobs:
 
   tests:
     name: 🧪 Test
-    timeout-minutes: 15
+    # Browser installation plus solution-app tests can exceed the setup budget.
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- raise the canonical workshop 🧪 Test job timeout from 15 to 30 minutes
- keep the 🔧 Setup job timeout at 15 minutes
- document why browser installation plus solution tests need additional headroom

## Context

The `react-server-components` deploy workflow was cancelled at the exact 15-minute job timeout in jobs [90558606678](https://github.com/epicweb-dev/react-server-components/actions/runs/30446658621/job/90558606678) and [90564052683](https://github.com/epicweb-dev/react-server-components/actions/runs/30448324703/job/90564052683), while Setup passed.

## Validation

- `npm run lint -- --fix`
- `npm run format`
- `npm run validate`
- parsed the canonical workflow and asserted Setup = 15, Test = 30, Deploy = 30
- all PR checks passed on Linux, macOS, and Windows
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3478faa6-5a8e-40f9-84cb-4f2538785620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3478faa6-5a8e-40f9-84cb-4f2538785620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

