### PR TITLE
fix: filter Firefox PiP user-activation Sentry noise (EPICSHOP-HE)

### DIFF
--- a/packages/workshop-app/app/utils/keyboard-shortcuts.client.ts
+++ b/packages/workshop-app/app/utils/keyboard-shortcuts.client.ts
@@ -447,7 +447,9 @@ function handleKeyDown(e: KeyboardEvent) {
 				muxPlayer.media &&
 				'requestPictureInPicture' in muxPlayer.media
 			) {
-				void (muxPlayer.media as HTMLVideoElement).requestPictureInPicture()
+				void (muxPlayer.media as HTMLVideoElement)
+					.requestPictureInPicture()
+					.catch(() => {})
 			}
 		}
 		// arrow up/down to adjust volume
@@ -588,7 +590,9 @@ function handleKeyDown(e: KeyboardEvent) {
 		if (document.pictureInPictureElement) {
 			void document.exitPictureInPicture().catch(() => {})
 		} else if ('requestPictureInPicture' in mediaElement) {
-			void (mediaElement as HTMLVideoElement).requestPictureInPicture()
+			void (mediaElement as HTMLVideoElement)
+				.requestPictureInPicture()
+				.catch(() => {})
 		}
 	}
 	// arrow up/down to adjust volume

--- a/packages/workshop-app/app/utils/monitoring.client.ts
+++ b/packages/workshop-app/app/utils/monitoring.client.ts
@@ -132,6 +132,7 @@ export function init() {
 		tracePropagationTargets,
 		ignoreErrors: [
 			"Failed to execute 'requestPictureInPicture' on 'HTMLVideoElement'",
+			'Picture-in-Picture requires user activation',
 			/^AbortError/,
 			/signal is aborted without reason/i,
 			/BodyStreamBuffer was aborted/i,

--- a/packages/workshop-app/app/utils/sentry-filters.ts
+++ b/packages/workshop-app/app/utils/sentry-filters.ts
@@ -33,6 +33,15 @@ type SentryEventWithException = {
 export const processingPictureInPictureRequestMessage =
 	'The video element is processing a Picture-in-Picture request.'
 
+/** Firefox (and some Chromium builds) when PiP is requested without transient activation. */
+export const pictureInPictureRequiresUserActivationMessage =
+	'Picture-in-Picture requires user activation'
+
+const pictureInPictureNotAllowedMessages = [
+	processingPictureInPictureRequestMessage,
+	pictureInPictureRequiresUserActivationMessage,
+] as const
+
 function getExceptionValues(event: SentryEventWithException) {
 	return event.exception?.values ?? []
 }
@@ -41,13 +50,20 @@ function exceptionValueText(value: SentryExceptionValue) {
 	return typeof value.value === 'string' ? value.value : ''
 }
 
+/**
+ * media-chrome / Mux Player PiP requests can reject with NotAllowedError when
+ * the browser drops transient user activation or another PiP request is in
+ * flight. Expected browser policy — not an actionable product defect.
+ */
 export function isProcessingPictureInPictureRequest(
 	event: SentryEventWithException,
 ) {
 	return getExceptionValues(event).some(
 		(value) =>
 			value.type === 'NotAllowedError' &&
-			value.value === processingPictureInPictureRequestMessage,
+			pictureInPictureNotAllowedMessages.some(
+				(message) => value.value === message,
+			),
 	)
 }
 

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -12,6 +12,7 @@ import {
 	isSessionStorageAccessDenied,
 	isStaleRouteResultNoise,
 	isUnexpectedServerErrorNoise,
+	pictureInPictureRequiresUserActivationMessage,
 	processingPictureInPictureRequestMessage,
 } from '../app/utils/sentry-filters.ts'
 import { isServerEnvironmentNoise } from '../sentry-server-filters.js'
@@ -24,6 +25,33 @@ test('matches the Picture-in-Picture processing DOMException exactly', () => {
 					{
 						type: 'NotAllowedError',
 						value: processingPictureInPictureRequestMessage,
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
+test('matches Firefox Picture-in-Picture user-activation NotAllowedError (aha)', () => {
+	expect(
+		isProcessingPictureInPictureRequest({
+			exception: {
+				values: [
+					{
+						type: 'NotAllowedError',
+						value: pictureInPictureRequiresUserActivationMessage,
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isClientSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'NotAllowedError',
+						value: pictureInPictureRequiresUserActivationMessage,
 					},
 				],
 			},
@@ -54,6 +82,18 @@ test('does not match the same message on a different exception type', () => {
 					{
 						type: 'SecurityError',
 						value: processingPictureInPictureRequestMessage,
+					},
+				],
+			},
+		}),
+	).toBe(false)
+	expect(
+		isProcessingPictureInPictureRequest({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: pictureInPictureRequiresUserActivationMessage,
 					},
 				],
 			},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Firefox rejects Picture-in-Picture with `NotAllowedError: Picture-in-Picture requires user activation` when transient user activation is missing; media-chrome's PiP button surfaces this as an unhandled rejection ([EPICSHOP-HE](https://kent-c-dodds-tech-llc.sentry.io/issues/7659891291/)).
- Extend the existing client PiP `NotAllowedError` filter and `ignoreErrors` to cover that Firefox signature (Chrome's "processing a Picture-in-Picture request" was already filtered).
- Swallow `requestPictureInPicture()` rejections in keyboard shortcuts (`i`) the same way we already swallow `exitPictureInPicture()`.

## Test plan

- [x] Extended `packages/workshop-app/tests/sentry-filters.test.ts` for the Firefox message
- [x] `npm run validate`
- [x] CI green; squash-merged as `e26e7d9f`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39da61f1-1845-4031-bcf5-291e3c7493a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39da61f1-1845-4031-bcf5-291e3c7493a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

